### PR TITLE
Fix : Initialize the cohesity cmdlet configuration

### DIFF
--- a/src/Cohesity.Powershell/Cohesity.PowerShell.psm1
+++ b/src/Cohesity.Powershell/Cohesity.PowerShell.psm1
@@ -13,3 +13,8 @@ Foreach($script in @($scripts))
         Write-Error -Message "Failed to import function $($script.fullname): $_"
     }
 }
+# Post module installation initialize the cmdlet configuration
+$config = Get-CohesityCmdletConfig
+if($null -eq $config) {
+    $resp = Set-CohesityCmdletConfig -LogSeverity 3
+}

--- a/src/Cohesity.Powershell/Scripts/Utility/Get-CohesityCmdletConfig.ps1
+++ b/src/Cohesity.Powershell/Scripts/Utility/Get-CohesityCmdletConfig.ps1
@@ -1,10 +1,11 @@
 function Get-CohesityCmdletConfig
 {
     [CmdletBinding()]
-    param(
-    )
+    param()
+
     Begin {
     }
+
     Process {
         [CohesityConfig]$config = [CohesityConfig]::New()
         $configFileName = $config.ConfigFileName
@@ -13,12 +14,10 @@ function Get-CohesityCmdletConfig
         if ([System.IO.File]::Exists($cmdletConfigPath)) {
             $config = Get-Content $cmdletConfigPath | ConvertFrom-Json
             $config
-        } else {
-            Write-Host "No configuration found for cohesity cmdlet, please setup using Set-CohesityCmdletConfig"
         }
     }
+
     End {
-        
     }
 }
 


### PR DESCRIPTION
The fix would seamlessly initialize the cmdlet configuration (if config does not exists) when a new session initializes. 