### PR TITLE
Fix : Set the job run id and the start time

### DIFF
--- a/src/Cohesity.Powershell/Cmdlets/Recovery/RestoreCohesityMSSQLObject.cs
+++ b/src/Cohesity.Powershell/Cmdlets/Recovery/RestoreCohesityMSSQLObject.cs
@@ -264,6 +264,20 @@ namespace Cohesity.Powershell.Cmdlets.Recovery
                 }
             };
 
+            if(false == JobRunId.HasValue || false == StartTime.HasValue)
+            {
+                //Set the latest job run for restoration
+                List<Model.ProtectionRunInstance> jobRuns = new List<Model.ProtectionRunInstance>(RestApiCommon.GetProtectionJobRunsByJobId(Session.ApiClient, JobId));
+                if (null != jobRuns && jobRuns.Count > 0)
+                {
+                    Model.ProtectionRunInstance jobRun = jobRuns[0];
+                    if (null != jobRun.CopyRun && jobRun.CopyRun.Count > 0)
+                    {
+                        JobRunId = jobRun.BackupRun.JobRunId;
+                        StartTime = jobRun.CopyRun[0].RunStartTimeUsecs;
+                    }
+                }
+            }
             if (JobRunId.HasValue)
                 hostingProtectionSource.JobRunId = JobRunId;
 


### PR DESCRIPTION
Set the job run id and the start time if either of them is not set.
Tested with restoring the DB in source SQL server, need to test in alternate SQL server.
Require one more SQL server to complete the tests.