### PR TITLE
Code styling for powershell cmdlet scripts

### DIFF
--- a/src/Cohesity.Powershell/Scripts/ProtectionJobRun/Set-CohesitySnapshotRetention.ps1
+++ b/src/Cohesity.Powershell/Scripts/ProtectionJobRun/Set-CohesitySnapshotRetention.ps1
@@ -13,7 +13,7 @@ function Set-CohesitySnapshotRetention {
         .EXAMPLE
         Set-CohesitySnapshotRetention -JobName Test-Job -JobRunId 2123 -ReduceByDays 30
     #>
-    [CmdletBinding(SupportsShouldProcess = $True, ConfirmImpact = "High")]
+    [CmdletBinding(DefaultParameterSetName = 'ExtendRetention', SupportsShouldProcess = $True, ConfirmImpact = "High")]
     Param(
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
@@ -131,7 +131,7 @@ function Set-CohesitySnapshotRetention {
                 elseif ($ReduceByDays) {
                     $message = "Reduced the snapshot retention successfully"
                 }
-                return $message
+                $message
             }
             else {
                 $errorMsg = "Snapshot retention : Failed to update the snapshot"

--- a/src/Cohesity.Powershell/Scripts/StorageDomain/Set-CohesityStorageDomain.ps1
+++ b/src/Cohesity.Powershell/Scripts/StorageDomain/Set-CohesityStorageDomain.ps1
@@ -23,7 +23,7 @@ function Set-CohesityStorageDomain {
         Set-CohesityStorageDomain -StorageDomain <object>
         Update the specified storage domain (view box) object.
     #>
-    [CmdletBinding(SupportsShouldProcess = $True, ConfirmImpact = "High")]
+    [CmdletBinding(DefaultParameterSetName = 'UpdateField', SupportsShouldProcess = $True, ConfirmImpact = "High")]
     Param(
         # Determines whether the compression policy should be 'kCompressionNone' (disabled case) or 'kCompressionLow' (enabled case)
         # 'kCompressionNone' indicates that data is not compressed. 'kCompressionLow' indicates that data is compressed.

--- a/src/Cohesity.Powershell/Scripts/Utility/Get-CohesityProtectionSourceSummary.ps1
+++ b/src/Cohesity.Powershell/Scripts/Utility/Get-CohesityProtectionSourceSummary.ps1
@@ -40,11 +40,11 @@ function Get-CohesityProtectionSourceSummary {
                     unprotectedSizeBytes = $resp.dashboard.protectedObjects.unprotectedSizeBytes
                 }
                 $result += $summary
-                return ($result  |Select-Object envType,protectedCount, `
+                ($result  |Select-Object envType,protectedCount, `
                 @{Name="protected size(GB)"; Expression={[math]::round($_.protectedSizeBytes/1GB, 2)}}, `
                 unprotectedCount, @{Name="unprotected size(GB)"; Expression={[math]::round($_.unprotectedSizeBytes/1GB, 2)}})
             } else {
-                return $resp
+                $resp
             }
         }
         else {

--- a/src/Cohesity.Powershell/Scripts/Utility/Set-CohesityCmdletConfig.ps1
+++ b/src/Cohesity.Powershell/Scripts/Utility/Set-CohesityCmdletConfig.ps1
@@ -12,7 +12,7 @@ class CohesityConfig {
 }
 $Global:CohesityCmdletConfig = $null
 function Set-CohesityCmdletConfig {
-    [CmdletBinding(SupportsShouldProcess = $True, ConfirmImpact = "High")]
+    [CmdletBinding(DefaultParameterSetName = 'LogSeverity', SupportsShouldProcess = $True, ConfirmImpact = "High")]
     param(
         [Parameter(Mandatory = $false, ParameterSetName = 'LogSeverity')]
         [ValidateSet(0, 1, 2, 3)]

--- a/src/Cohesity.Powershell/Scripts/Vlan/Remove-CohesityVlan.ps1
+++ b/src/Cohesity.Powershell/Scripts/Vlan/Remove-CohesityVlan.ps1
@@ -13,7 +13,7 @@ function Remove-CohesityVlan {
         .EXAMPLE
         Get-CohesityVlan -VlanId 11 | Remove-CohesityVlan
     #>
-    [CmdletBinding(SupportsShouldProcess = $True, ConfirmImpact = "High", DefaultParameterSetName = "PipedVlanInfo")]
+    [CmdletBinding(DefaultParameterSetName = "PipedVlanInfo", SupportsShouldProcess = $True, ConfirmImpact = "High")]
     Param(
         [Parameter(Mandatory = $true, ParameterSetName = 'VlanId')]
         [ValidateNotNullOrEmpty()]

--- a/src/Cohesity.Powershell/Scripts/Vlan/Update-CohesityVlan.ps1
+++ b/src/Cohesity.Powershell/Scripts/Vlan/Update-CohesityVlan.ps1
@@ -13,7 +13,7 @@ function Update-CohesityVlan {
         .EXAMPLE
         Get-CohesityVlan -VlanId 11 |  Update-CohesityVlan -InterfaceGroupName intf_group1 -Subnet 1.2.1.1
     #>
-    [CmdletBinding(SupportsShouldProcess = $True, ConfirmImpact = "High")]
+    [CmdletBinding(DefaultParameterSetName = "InterfaceGroupName", SupportsShouldProcess = $True, ConfirmImpact = "High")]
     Param(
         [Parameter(Mandatory = $true, ParameterSetName = 'InterfaceGroupName')]
         [Parameter(Mandatory = $false, ParameterSetName = 'PipedVlanInfo')]


### PR DESCRIPTION
Fixed
- Avoid using return object, simply send the object, it can be used in
piping
- Use DefaultParameterSetName wherever ParameterSet is used