### PR TITLE
v1.8.0 release changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ You can install Cohesity PowerShell Module directly using the [PowerShell Galler
   Install-Module -Name Cohesity.PowerShell
   ```
 
+  ** Note: Windows with powershell version 7 or higher supports only Powershell Core
+
 ## <a name="examples"></a> Some samples to get you going :bulb:
 
 * Refer [`samples`](./samples) folder to find more examples.

--- a/docs/cmdlets-reference/get-cohesityviewdirectoryquota.md
+++ b/docs/cmdlets-reference/get-cohesityviewdirectoryquota.md
@@ -19,6 +19,11 @@ The Get-CohesityViewDirectoryQuota function is used to fetch directory quota for
 Get-CohesityViewDirectoryQuota -ViewName view1
 ```
 
+### EXAMPLE 2
+```
+Get-CohesityViewDirectoryQuota -ViewName view1 -PageCount 10
+```
+
 ## PARAMETERS
 
 ### -ViewName
@@ -32,6 +37,21 @@ Aliases:
 Required: False
 Position: 1
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PageCount
+Specifies the number of view directory quota need to be returned while calling rest api
+
+```yaml
+Type: Integer
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -8,6 +8,7 @@ You can install Cohesity PowerShell Module directly using the [PowerShell Galler
   > **Tip:** Please follow the steps based on the flavor of PowerShell that you are running.
   * If installing on `MacOS` and `Linux` you must use the steps for `PowerShell Core`.
   * If installing on `Windows` you should use the steps for `Windows PowerShell`, unless you are running `PowerShell Core`.
+  **NOTE:** Windows with powershell version 7 or higher requires `Cohesity.Powershell.core`.
 
 <!-- tabs:start -->
 

--- a/src/Cohesity.Powershell.Models/Alert.cs
+++ b/src/Cohesity.Powershell.Models/Alert.cs
@@ -46,124 +46,226 @@ namespace Cohesity.Model
             KCluster = 3,
 
             /// <summary>
+            /// Enum KChassis for value: kChassis
+            /// </summary>
+            [EnumMember(Value = "kChassis")]
+            KChassis = 4,
+
+            /// <summary>
+            /// Enum KPowerSupply for value: kPowerSupply
+            /// </summary>
+            [EnumMember(Value = "kPowerSupply")]
+            KPowerSupply = 5,
+
+            /// <summary>
+            /// Enum KCPU for value: kCPU
+            /// </summary>
+            [EnumMember(Value = "kCPU")]
+            KCPU = 6,
+
+            /// <summary>
+            /// Enum KMemory for value: kMemory
+            /// </summary>
+            [EnumMember(Value = "kMemory")]
+            KMemory = 7,
+
+            /// <summary>
+            /// Enum KTemperature for value: kTemperature
+            /// </summary>
+            [EnumMember(Value = "kTemperature")]
+            KTemperature = 8,
+
+            /// <summary>
+            /// Enum KFan for value: kFan
+            /// </summary>
+            [EnumMember(Value = "kFan")]
+            KFan = 9,
+
+            /// <summary>
+            /// Enum KNIC for value: kNIC
+            /// </summary>
+            [EnumMember(Value = "kNIC")]
+            KNIC = 10,
+
+            /// <summary>
+            /// Enum KFirmware for value: kFirmware
+            /// </summary>
+            [EnumMember(Value = "kFirmware")]
+            KFirmware = 11,
+
+            /// <summary>
             /// Enum KNodeHealth for value: kNodeHealth
             /// </summary>
             [EnumMember(Value = "kNodeHealth")]
-            KNodeHealth = 4,
+            KNodeHealth = 12,
 
             /// <summary>
-            /// Enum KClusterHealth for value: kClusterHealth
+            /// Enum KOperatingSystem for value: kOperatingSystem
             /// </summary>
-            [EnumMember(Value = "kClusterHealth")]
-            KClusterHealth = 5,
-
-            /// <summary>
-            /// Enum KBackupRestore for value: kBackupRestore
-            /// </summary>
-            [EnumMember(Value = "kBackupRestore")]
-            KBackupRestore = 6,
-
-            /// <summary>
-            /// Enum KEncryption for value: kEncryption
-            /// </summary>
-            [EnumMember(Value = "kEncryption")]
-            KEncryption = 7,
-
-            /// <summary>
-            /// Enum KArchivalRestore for value: kArchivalRestore
-            /// </summary>
-            [EnumMember(Value = "kArchivalRestore")]
-            KArchivalRestore = 8,
-
-            /// <summary>
-            /// Enum KRemoteReplication for value: kRemoteReplication
-            /// </summary>
-            [EnumMember(Value = "kRemoteReplication")]
-            KRemoteReplication = 9,
-
-            /// <summary>
-            /// Enum KQuota for value: kQuota
-            /// </summary>
-            [EnumMember(Value = "kQuota")]
-            KQuota = 10,
-
-            /// <summary>
-            /// Enum KLicense for value: kLicense
-            /// </summary>
-            [EnumMember(Value = "kLicense")]
-            KLicense = 11,
-
-            /// <summary>
-            /// Enum KHeliosProActiveWellness for value: kHeliosProActiveWellness
-            /// </summary>
-            [EnumMember(Value = "kHeliosProActiveWellness")]
-            KHeliosProActiveWellness = 12,
-
-            /// <summary>
-            /// Enum KHeliosAnalyticsJobs for value: kHeliosAnalyticsJobs
-            /// </summary>
-            [EnumMember(Value = "kHeliosAnalyticsJobs")]
-            KHeliosAnalyticsJobs = 13,
-
-            /// <summary>
-            /// Enum KHeliosSignatureJobs for value: kHeliosSignatureJobs
-            /// </summary>
-            [EnumMember(Value = "kHeliosSignatureJobs")]
-            KHeliosSignatureJobs = 14,
-
-            /// <summary>
-            /// Enum KSecurity for value: kSecurity
-            /// </summary>
-            [EnumMember(Value = "kSecurity")]
-            KSecurity = 15,
-
-            /// <summary>
-            /// Enum KAppsInfra for value: kAppsInfra
-            /// </summary>
-            [EnumMember(Value = "kAppsInfra")]
-            KAppsInfra = 16,
-
-            /// <summary>
-            /// Enum KAntivirus for value: kAntivirus
-            /// </summary>
-            [EnumMember(Value = "kAntivirus")]
-            KAntivirus = 17,
-
-            /// <summary>
-            /// Enum KArchivalCopy for value: kArchivalCopy
-            /// </summary>
-            [EnumMember(Value = "kArchivalCopy")]
-            KArchivalCopy = 18,
-
-            /// <summary>
-            /// Enum KUpgrade for value: kUpgrade
-            /// </summary>
-            [EnumMember(Value = "kUpgrade")]
-            KUpgrade = 19,
-
-            /// <summary>
-            /// Enum KNetworking for value: kNetworking
-            /// </summary>
-            [EnumMember(Value = "kNetworking")]
-            KNetworking = 20,
-
-            /// <summary>
-            /// Enum KStorageUsage for value: kStorageUsage
-            /// </summary>
-            [EnumMember(Value = "kStorageUsage")]
-            KStorageUsage = 21,
+            [EnumMember(Value = "kOperatingSystem")]
+            KOperatingSystem = 13,
 
             /// <summary>
             /// Enum KDataPath for value: kDataPath
             /// </summary>
             [EnumMember(Value = "kDataPath")]
-            KDataPath = 22,
+            KDataPath = 14,
+
+            /// <summary>
+            /// Enum KMetadata for value: kMetadata
+            /// </summary>
+            [EnumMember(Value = "kMetadata")]
+            KMetadata = 15,
 
             /// <summary>
             /// Enum KIndexing for value: kIndexing
             /// </summary>
             [EnumMember(Value = "kIndexing")]
-            KIndexing = 23
+            KIndexing = 16,
+
+            /// <summary>
+            /// Enum KHelios for value: kHelios
+            /// </summary>
+            [EnumMember(Value = "kHelios")]
+            KHelios = 17,
+
+            /// <summary>
+            /// Enum KAppMarketPlace for value: kAppMarketPlace
+            /// </summary>
+            [EnumMember(Value = "kAppMarketPlace")]
+            KAppMarketPlace = 18,
+
+            /// <summary>
+            /// Enum KLicense for value: kLicense
+            /// </summary>
+            [EnumMember(Value = "kLicense")]
+            KLicense = 19,
+
+            /// <summary>
+            /// Enum KSecurity for value: kSecurity
+            /// </summary>
+            [EnumMember(Value = "kSecurity")]
+            KSecurity = 20,
+
+            /// <summary>
+            /// Enum KUpgrade for value: kUpgrade
+            /// </summary>
+            [EnumMember(Value = "kUpgrade")]
+            KUpgrade = 21,
+
+            /// <summary>
+            /// Enum KClusterManagement for value: kClusterManagement
+            /// </summary>
+            [EnumMember(Value = "kClusterManagement")]
+            KClusterManagement = 22,
+
+            /// <summary>
+            /// Enum KAuditLog for value: kAuditLog
+            /// </summary>
+            [EnumMember(Value = "kAuditLog")]
+            KAuditLog = 23,
+
+            /// <summary>
+            /// Enum KNetworking for value: kNetworking
+            /// </summary>
+            [EnumMember(Value = "kNetworking")]
+            KNetworking = 24,
+
+            /// <summary>
+            /// Enum KConfiguration for value: kConfiguration
+            /// </summary>
+            [EnumMember(Value = "kConfiguration")]
+            KConfiguration = 25,
+
+            /// <summary>
+            /// Enum KStorageUsage for value: kStorageUsage
+            /// </summary>
+            [EnumMember(Value = "kStorageUsage")]
+            KStorageUsage = 26,
+
+            /// <summary>
+            /// Enum KFaultTolerance for value: kFaultTolerance
+            /// </summary>
+            [EnumMember(Value = "kFaultTolerance")]
+            KFaultTolerance = 27,
+
+            /// <summary>
+            /// Enum KBackupRestore for value: kBackupRestore
+            /// </summary>
+            [EnumMember(Value = "kBackupRestore")]
+            KBackupRestore = 28,
+
+            /// <summary>
+            /// Enum KArchivalRestore for value: kArchivalRestore
+            /// </summary>
+            [EnumMember(Value = "kArchivalRestore")]
+            KArchivalRestore = 29,
+
+            /// <summary>
+            /// Enum KRemoteReplication for value: kRemoteReplication
+            /// </summary>
+            [EnumMember(Value = "kRemoteReplication")]
+            KRemoteReplication = 30,
+
+            /// <summary>
+            /// Enum KQuota for value: kQuota
+            /// </summary>
+            [EnumMember(Value = "kQuota")]
+            KQuota = 31,
+
+            /// <summary>
+            /// Enum KCDP for value: kCDP
+            /// </summary>
+            [EnumMember(Value = "kCDP")]
+            KCDP = 32,
+
+            /// <summary>
+            /// Enum KClusterHealth for value: kClusterHealth
+            /// </summary>
+            [EnumMember(Value = "kClusterHealth")]
+            KClusterHealth = 33,
+
+            /// <summary>
+            /// Enum KEncryption for value: kEncryption
+            /// </summary>
+            [EnumMember(Value = "kEncryption")]
+            KEncryption = 34,
+
+            /// <summary>
+            /// Enum KHeliosProActiveWellness for value: kHeliosProActiveWellness
+            /// </summary>
+            [EnumMember(Value = "kHeliosProActiveWellness")]
+            KHeliosProActiveWellness = 35,
+
+            /// <summary>
+            /// Enum KHeliosAnalyticsJobs for value: kHeliosAnalyticsJobs
+            /// </summary>
+            [EnumMember(Value = "kHeliosAnalyticsJobs")]
+            KHeliosAnalyticsJobs = 36,
+
+            /// <summary>
+            /// Enum KHeliosSignatureJobs for value: kHeliosSignatureJobs
+            /// </summary>
+            [EnumMember(Value = "kHeliosSignatureJobs")]
+            KHeliosSignatureJobs = 37,
+
+            /// <summary>
+            /// Enum KAppsInfra for value: kAppsInfra
+            /// </summary>
+            [EnumMember(Value = "kAppsInfra")]
+            KAppsInfra = 38,
+
+            /// <summary>
+            /// Enum KAntivirus for value: kAntivirus
+            /// </summary>
+            [EnumMember(Value = "kAntivirus")]
+            KAntivirus = 39,
+
+            /// <summary>
+            /// Enum KArchivalCopy for value: kArchivalCopy
+            /// </summary>
+            [EnumMember(Value = "kArchivalCopy")]
+            KArchivalCopy = 40
 
         }
 
@@ -220,40 +322,40 @@ namespace Cohesity.Model
         public enum AlertTypeBucketEnum
         {
             /// <summary>
-            /// Enum KSoftware for value: kSoftware
-            /// </summary>
-            [EnumMember(Value = "kSoftware")]
-            KSoftware = 1,
-
-            /// <summary>
             /// Enum KHardware for value: kHardware
             /// </summary>
             [EnumMember(Value = "kHardware")]
-            KHardware = 2,
+            KHardware = 1,
 
             /// <summary>
-            /// Enum KService for value: kService
+            /// Enum KSoftware for value: kSoftware
             /// </summary>
-            [EnumMember(Value = "kService")]
-            KService = 3,
-
-            /// <summary>
-            /// Enum KOther for value: kOther
-            /// </summary>
-            [EnumMember(Value = "kOther")]
-            KOther = 4,
-
-            /// <summary>
-            /// Enum KMaintenance for value: kMaintenance
-            /// </summary>
-            [EnumMember(Value = "kMaintenance")]
-            KMaintenance = 5,
+            [EnumMember(Value = "kSoftware")]
+            KSoftware = 2,
 
             /// <summary>
             /// Enum KDataService for value: kDataService
             /// </summary>
             [EnumMember(Value = "kDataService")]
-            KDataService = 6
+            KDataService = 3,
+
+            /// <summary>
+            /// Enum KMaintenance for value: kMaintenance
+            /// </summary>
+            [EnumMember(Value = "kMaintenance")]
+            KMaintenance = 4,
+
+            /// <summary>
+            /// Enum KService for value: kService
+            /// </summary>
+            [EnumMember(Value = "kService")]
+            KService = 5,
+
+            /// <summary>
+            /// Enum KOther for value: kOther
+            /// </summary>
+            [EnumMember(Value = "kOther")]
+            KOther = 6
 
         }
 

--- a/src/Cohesity.Powershell.Models/AlertCategoryName.cs
+++ b/src/Cohesity.Powershell.Models/AlertCategoryName.cs
@@ -46,94 +46,226 @@ namespace Cohesity.Model
             KCluster = 3,
 
             /// <summary>
+            /// Enum KChassis for value: kChassis
+            /// </summary>
+            [EnumMember(Value = "kChassis")]
+            KChassis = 4,
+
+            /// <summary>
+            /// Enum KPowerSupply for value: kPowerSupply
+            /// </summary>
+            [EnumMember(Value = "kPowerSupply")]
+            KPowerSupply = 5,
+
+            /// <summary>
+            /// Enum KCPU for value: kCPU
+            /// </summary>
+            [EnumMember(Value = "kCPU")]
+            KCPU = 6,
+
+            /// <summary>
+            /// Enum KMemory for value: kMemory
+            /// </summary>
+            [EnumMember(Value = "kMemory")]
+            KMemory = 7,
+
+            /// <summary>
+            /// Enum KTemperature for value: kTemperature
+            /// </summary>
+            [EnumMember(Value = "kTemperature")]
+            KTemperature = 8,
+
+            /// <summary>
+            /// Enum KFan for value: kFan
+            /// </summary>
+            [EnumMember(Value = "kFan")]
+            KFan = 9,
+
+            /// <summary>
+            /// Enum KNIC for value: kNIC
+            /// </summary>
+            [EnumMember(Value = "kNIC")]
+            KNIC = 10,
+
+            /// <summary>
+            /// Enum KFirmware for value: kFirmware
+            /// </summary>
+            [EnumMember(Value = "kFirmware")]
+            KFirmware = 11,
+
+            /// <summary>
             /// Enum KNodeHealth for value: kNodeHealth
             /// </summary>
             [EnumMember(Value = "kNodeHealth")]
-            KNodeHealth = 4,
+            KNodeHealth = 12,
 
             /// <summary>
-            /// Enum KClusterHealth for value: kClusterHealth
+            /// Enum KOperatingSystem for value: kOperatingSystem
             /// </summary>
-            [EnumMember(Value = "kClusterHealth")]
-            KClusterHealth = 5,
+            [EnumMember(Value = "kOperatingSystem")]
+            KOperatingSystem = 13,
 
             /// <summary>
-            /// Enum KBackupRestore for value: kBackupRestore
+            /// Enum KDataPath for value: kDataPath
             /// </summary>
-            [EnumMember(Value = "kBackupRestore")]
-            KBackupRestore = 6,
+            [EnumMember(Value = "kDataPath")]
+            KDataPath = 14,
 
             /// <summary>
-            /// Enum KEncryption for value: kEncryption
+            /// Enum KMetadata for value: kMetadata
             /// </summary>
-            [EnumMember(Value = "kEncryption")]
-            KEncryption = 7,
+            [EnumMember(Value = "kMetadata")]
+            KMetadata = 15,
 
             /// <summary>
-            /// Enum KArchivalRestore for value: kArchivalRestore
+            /// Enum KIndexing for value: kIndexing
             /// </summary>
-            [EnumMember(Value = "kArchivalRestore")]
-            KArchivalRestore = 8,
+            [EnumMember(Value = "kIndexing")]
+            KIndexing = 16,
 
             /// <summary>
-            /// Enum KRemoteReplication for value: kRemoteReplication
+            /// Enum KHelios for value: kHelios
             /// </summary>
-            [EnumMember(Value = "kRemoteReplication")]
-            KRemoteReplication = 9,
+            [EnumMember(Value = "kHelios")]
+            KHelios = 17,
 
             /// <summary>
-            /// Enum KQuota for value: kQuota
+            /// Enum KAppMarketPlace for value: kAppMarketPlace
             /// </summary>
-            [EnumMember(Value = "kQuota")]
-            KQuota = 10,
+            [EnumMember(Value = "kAppMarketPlace")]
+            KAppMarketPlace = 18,
 
             /// <summary>
             /// Enum KLicense for value: kLicense
             /// </summary>
             [EnumMember(Value = "kLicense")]
-            KLicense = 11,
-
-            /// <summary>
-            /// Enum KHeliosProActiveWellness for value: kHeliosProActiveWellness
-            /// </summary>
-            [EnumMember(Value = "kHeliosProActiveWellness")]
-            KHeliosProActiveWellness = 12,
-
-            /// <summary>
-            /// Enum KHeliosAnalyticsJobs for value: kHeliosAnalyticsJobs
-            /// </summary>
-            [EnumMember(Value = "kHeliosAnalyticsJobs")]
-            KHeliosAnalyticsJobs = 13,
-
-            /// <summary>
-            /// Enum KHeliosSignatureJobs for value: kHeliosSignatureJobs
-            /// </summary>
-            [EnumMember(Value = "kHeliosSignatureJobs")]
-            KHeliosSignatureJobs = 14,
+            KLicense = 19,
 
             /// <summary>
             /// Enum KSecurity for value: kSecurity
             /// </summary>
             [EnumMember(Value = "kSecurity")]
-            KSecurity = 15,
+            KSecurity = 20,
+
+            /// <summary>
+            /// Enum KUpgrade for value: kUpgrade
+            /// </summary>
+            [EnumMember(Value = "kUpgrade")]
+            KUpgrade = 21,
+
+            /// <summary>
+            /// Enum KClusterManagement for value: kClusterManagement
+            /// </summary>
+            [EnumMember(Value = "kClusterManagement")]
+            KClusterManagement = 22,
+
+            /// <summary>
+            /// Enum KAuditLog for value: kAuditLog
+            /// </summary>
+            [EnumMember(Value = "kAuditLog")]
+            KAuditLog = 23,
+
+            /// <summary>
+            /// Enum KNetworking for value: kNetworking
+            /// </summary>
+            [EnumMember(Value = "kNetworking")]
+            KNetworking = 24,
+
+            /// <summary>
+            /// Enum KConfiguration for value: kConfiguration
+            /// </summary>
+            [EnumMember(Value = "kConfiguration")]
+            KConfiguration = 25,
+
+            /// <summary>
+            /// Enum KStorageUsage for value: kStorageUsage
+            /// </summary>
+            [EnumMember(Value = "kStorageUsage")]
+            KStorageUsage = 26,
+
+            /// <summary>
+            /// Enum KFaultTolerance for value: kFaultTolerance
+            /// </summary>
+            [EnumMember(Value = "kFaultTolerance")]
+            KFaultTolerance = 27,
+
+            /// <summary>
+            /// Enum KBackupRestore for value: kBackupRestore
+            /// </summary>
+            [EnumMember(Value = "kBackupRestore")]
+            KBackupRestore = 28,
+
+            /// <summary>
+            /// Enum KArchivalRestore for value: kArchivalRestore
+            /// </summary>
+            [EnumMember(Value = "kArchivalRestore")]
+            KArchivalRestore = 29,
+
+            /// <summary>
+            /// Enum KRemoteReplication for value: kRemoteReplication
+            /// </summary>
+            [EnumMember(Value = "kRemoteReplication")]
+            KRemoteReplication = 30,
+
+            /// <summary>
+            /// Enum KQuota for value: kQuota
+            /// </summary>
+            [EnumMember(Value = "kQuota")]
+            KQuota = 31,
+
+            /// <summary>
+            /// Enum KCDP for value: kCDP
+            /// </summary>
+            [EnumMember(Value = "kCDP")]
+            KCDP = 32,
+
+            /// <summary>
+            /// Enum KClusterHealth for value: kClusterHealth
+            /// </summary>
+            [EnumMember(Value = "kClusterHealth")]
+            KClusterHealth = 33,
+
+            /// <summary>
+            /// Enum KEncryption for value: kEncryption
+            /// </summary>
+            [EnumMember(Value = "kEncryption")]
+            KEncryption = 34,
+
+            /// <summary>
+            /// Enum KHeliosProActiveWellness for value: kHeliosProActiveWellness
+            /// </summary>
+            [EnumMember(Value = "kHeliosProActiveWellness")]
+            KHeliosProActiveWellness = 35,
+
+            /// <summary>
+            /// Enum KHeliosAnalyticsJobs for value: kHeliosAnalyticsJobs
+            /// </summary>
+            [EnumMember(Value = "kHeliosAnalyticsJobs")]
+            KHeliosAnalyticsJobs = 36,
+
+            /// <summary>
+            /// Enum KHeliosSignatureJobs for value: kHeliosSignatureJobs
+            /// </summary>
+            [EnumMember(Value = "kHeliosSignatureJobs")]
+            KHeliosSignatureJobs = 37,
 
             /// <summary>
             /// Enum KAppsInfra for value: kAppsInfra
             /// </summary>
             [EnumMember(Value = "kAppsInfra")]
-            KAppsInfra = 16,
+            KAppsInfra = 38,
 
             /// <summary>
             /// Enum KAntivirus for value: kAntivirus
             /// </summary>
             [EnumMember(Value = "kAntivirus")]
-            KAntivirus = 17,
+            KAntivirus = 39,
 
             /// <summary>
             /// Enum KArchivalCopy for value: kArchivalCopy
             /// </summary>
             [EnumMember(Value = "kArchivalCopy")]
-            KArchivalCopy = 18
+            KArchivalCopy = 40
 
         }
 

--- a/src/Cohesity.Powershell.Models/RestoreTask.cs
+++ b/src/Cohesity.Powershell.Models/RestoreTask.cs
@@ -85,7 +85,13 @@ namespace Cohesity.Model
             /// Enum KCancelled for value: kCancelled
             /// </summary>
             [EnumMember(Value = "kCancelled")]
-            KCancelled = 10
+            KCancelled = 10,
+
+            /// <summary>
+            /// Enum KOnHold for value: kOnHold
+            /// </summary>
+            [EnumMember(Value = "kOnHold")]
+            KOnHold = 11
 
         }
 

--- a/src/Cohesity.Powershell/Cohesity.PowerShell.Core.psd1
+++ b/src/Cohesity.Powershell/Cohesity.PowerShell.Core.psd1
@@ -8,7 +8,7 @@
 RootModule = 'Cohesity.PowerShell.Core.dll'
 
 # Version number of this module.
-ModuleVersion = '1.7.8'
+ModuleVersion = '1.8.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/Cohesity.Powershell/Cohesity.PowerShell.psd1
+++ b/src/Cohesity.Powershell/Cohesity.PowerShell.psd1
@@ -8,7 +8,7 @@
 RootModule = 'Cohesity.PowerShell.dll'
 
 # Version number of this module.
-ModuleVersion = '1.7.8'
+ModuleVersion = '1.8.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/Cohesity.Powershell/Scripts/ProtectionJob/Set-CohesityProtectionJob.ps1
+++ b/src/Cohesity.Powershell/Scripts/ProtectionJob/Set-CohesityProtectionJob.ps1
@@ -37,8 +37,13 @@ function Set-CohesityProtectionJob {
 
     Process {
         $protectionJobName = $ProtectionJob.Name
-        if ($PSCmdlet.ShouldProcess($protectionJobName)) {
 
+        # Check if the sourceId field is an array or not, if not convert it into array
+        if ($ProtectionJob.sourceIds -is "int" -eq $True ) {
+            $ProtectionJob.sourceIds = [int[]](($ProtectionJob.sourceIds -split ',') -ne '')
+        }
+
+        if ($PSCmdlet.ShouldProcess($protectionJobName)) {
             if ($ProtectionJob.Environment -eq "kPhysicalFiles" -and -not $ProtectionJob.SourceSpecialParameters) {
                 $job = Get-CohesityProtectionJob -Ids $ProtectionJob.Id
                 if ($job) {

--- a/src/Cohesity.Powershell/Scripts/View/Get-CohesityViewDirectoryQuota.ps1
+++ b/src/Cohesity.Powershell/Scripts/View/Get-CohesityViewDirectoryQuota.ps1
@@ -6,13 +6,20 @@ function Get-CohesityViewDirectoryQuota {
         The Get-CohesityViewDirectoryQuota function is used to fetch directory quota for a view.
         .EXAMPLE
         Get-CohesityViewDirectoryQuota -ViewName view1
+        .Example
+        Get-CohesityViewDirectoryQuota -ViewName view1 -PageCount 10
+        Returns only specified count of view directory quota for each rest api call
     #>
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory = $false)]
         [ValidateNotNullOrEmpty()]
         # Specifies view name.
-        [String]$ViewName
+        [String]$ViewName,
+        # Specifies number of views to be returned in each api call
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(1, [int]::MaxValue)]
+        [int]$PageCount=0
     )
 
     Begin {
@@ -24,8 +31,41 @@ function Get-CohesityViewDirectoryQuota {
             Write-Output "The view '$ViewName' does not exists."
             return
         }
+
         $cohesityClusterURL = '/irisservices/api/v1/public/viewDirectoryQuotas?viewName='+$ViewName
+
+        if ($pageCount -gt 0) {
+            $cohesityClusterURL+='&pageCount='+$pageCount
+        }
+
         $resp = Invoke-RestApi -Method 'Get' -Uri $cohesityClusterURL
+        $cookie = $resp.cookie
+
+        # Loop to get all of the paged data
+        $pageNum=1
+        $pagesMax=10000
+
+        # If cookies occurs, loop through maximum count to fetch all quotas of the view
+        while ($cookie) {
+            $pageNum++ # First page datas are already collected, before first iteration
+
+            # Limit the number of iterations if something goes wrong
+            if ($pageNum -gt $pagesMax) {
+                Write-Error "Get-CohesityViewDirectoryQuota() api page count exceeded $pagesMax. Too many quotas. Try increasing PageCount parameter"
+                return
+            }
+
+            $cohesityViewDirQuotaURL=$cohesityClusterURL+'&cookie='+$cookie
+            $quotaRespAdd = Invoke-RestApi -Method 'Get' -Uri $cohesityViewDirQuotaURL
+            $cookie = $quotaRespAdd.cookie
+
+            if (@($quotaRespAdd.quotas).count) {
+                $resp.quotas+=@($quotaRespAdd.quotas)
+            }
+        }
+
+        # Remove cookie value from the results as it is meaningless to the caller
+        $resp.PSObject.Properties.Remove('cookie')
         $resp
     }
 }

--- a/src/PublishOnLocalRepo.ps1
+++ b/src/PublishOnLocalRepo.ps1
@@ -1,4 +1,4 @@
-$localRepoPath="C:\workspace\MyServer\MyServer\Packages\"
+$localRepoPath="C:\Users\Administrator\source\repos\NuGetServerApp\NuGetServerApp\Packages\"
 $powerShellPackage=$localRepoPath+"Cohesity.PowerShell"
 $powerShellCorePackage=$localRepoPath+"Cohesity.PowerShell.Core"
 Remove-Item -Recurse -Force $powerShellPackage


### PR DESCRIPTION
1. Modified verison to 1.8.0
2. Updated readme and setup file with saying windows with powershell version 7 or higher supports only cohesity.powershell.core module
3. Fixed following github issues:
a. Issue: Error converting value "kConfiguration" to type 'System.Nullable`1[Cohesity.Model.Alert+AlertCategoryEnum]'. Path '[0].alertCategory'
Cause: 'KConfiguration' enum value is missing in AlertCategoryEnum field in the Alert.cs model
Issue Link: https://github.com/cohesity/cohesity-powershell-module/issues/185
b.  Issue: On views with larger numbers of directory quotes, Get-CohesityViewDirectoryQuota fails to return all of the quotas.
Fix: Adding cookie value returned from rest api call to the cohesity url to fetch the remaining quotas until page maximum(10000) reaches or cookie field is empty
Issue Link: https://github.com/cohesity/cohesity-powershell-module/issues/183
c. Issue: Updating Protection job fails.
Cause: when the source Id of updating protection job field is edited and contains only one value, its considered as integer, which throws data type error while calling update rest api for protection job
Fix: If the data type of sourceIds field is integer, converting it into array
Issue Link: https://github.com/cohesity/cohesity-powershell-module/issues/187