### PR TITLE
Issue No: 196

### DIFF
--- a/docs/cmdlets-reference/get-cohesityprotectionsource.md
+++ b/docs/cmdlets-reference/get-cohesityprotectionsource.md
@@ -26,6 +26,15 @@ Returns registered protection sources that match the environment type 'kVMware'.
 Get-CohesityProtectionSource -Id 1234
 ```
 
+Returns registered protection source that matches the id 1234.
+
+### EXAMPLE 3
+```
+Get-CohesityProtectionSource -Name 'abc'
+```
+
+Returns registered protection sources that matches the name 'abc'.
+
 ## PARAMETERS
 
 ### -Environments

--- a/src/Cohesity.Powershell/Scripts/ProtectionJob/Set-CohesityProtectionJob.ps1
+++ b/src/Cohesity.Powershell/Scripts/ProtectionJob/Set-CohesityProtectionJob.ps1
@@ -44,7 +44,7 @@ function Set-CohesityProtectionJob {
         }
 
         if ($PSCmdlet.ShouldProcess($protectionJobName)) {
-            if ($ProtectionJob.Environment -eq "kPhysicalFiles" -and -not $ProtectionJob.SourceSpecialParameters) {
+            if ($ProtectionJob.Environment -eq "kPhysicalFiles") {
                 $job = Get-CohesityProtectionJob -Ids $ProtectionJob.Id
                 if ($job) {
                     if ($job.SourceSpecialParameters) {

--- a/src/Cohesity.Powershell/Scripts/ProtectionSource/Get-CohesityProtectionSource.ps1
+++ b/src/Cohesity.Powershell/Scripts/ProtectionSource/Get-CohesityProtectionSource.ps1
@@ -13,6 +13,10 @@ function Get-CohesityProtectionSource {
         Returns registered protection sources that match the environment type 'kVMware'.
         .EXAMPLE
         Get-CohesityProtectionSource -Id 1234
+        Returns registered protection source that matches the id 1234.
+        .EXAMPLE
+        Get-CohesityProtectionSource -Name 'abc'
+        Returns registered protection sources that matches the name 'abc'.
     #>
     [OutputType('System.Array')]
     [CmdletBinding()]
@@ -23,7 +27,10 @@ function Get-CohesityProtectionSource {
         [Cohesity.Model.ProtectionSource+EnvironmentEnum[]]$Environments,
         [Parameter(Mandatory = $false)]
         # Return only the protection source that matches the Id.
-        [long]$Id
+        [long]$Id,
+        [Parameter(Mandatory = $false)]
+        # Return only the protection source that matches the sepecified object name.
+        [String]$Name
     )
 
     Begin {
@@ -31,13 +38,30 @@ function Get-CohesityProtectionSource {
 
     Process {
         if ($Id) {
-            $cohesityUrl = '/irisservices/api/v1/public/protectionSources/objects/' + $Id.ToString()
-            $resp = Invoke-RestApi -Method Get -Uri $cohesityUrl
+            $PSObjectUrl = '/irisservices/api/v1/public/protectionSources/objects/' + $Id.ToString()
+            $resp = Invoke-RestApi -Method Get -Uri $PSObjectUrl
+
             # tagging reponse for display format ( configured in Cohesity.format.ps1xml )
             @($resp | Add-Member -TypeName 'System.Object#ProtectionSource' -PassThru)
-        }
-        else {
-            $url = '/irisservices/api/v1/public/protectionSources/rootNodes'
+        } elseif ($Name) {
+            $PSObjectUrl = '/irisservices/api/v1/public/protectionSources/objects'
+            $PSObjectResp = Invoke-RestApi -Method Get -Uri $PSObjectUrl
+
+            if ($PSObjectResp) {
+                # Skip kView, kAgent, kPuppeteer environment types and group nodes themselves
+                $PSObjectResp = @($PSObjectResp | where-object {
+                    $_.environment -ne "kAgent" `
+                    -and $_.environment -ne "kView" `
+                    -and $_.environment -ne "kPuppeteer"
+                })
+
+                $PSObject = @($PSObjectResp | where-object { $Name -eq $_.name })
+
+                # tagging reponse for display format ( configured in Cohesity.format.ps1xml )
+                @($PSObject | Add-Member -TypeName 'System.Object#ProtectionSource' -PassThru)
+            }
+        } else {
+            $rootNodeUrl = '/irisservices/api/v1/public/protectionSources/rootNodes'
             if ($Environments) {
                 $envList = @()
                 foreach ($item in $Environments) {
@@ -45,18 +69,20 @@ function Get-CohesityProtectionSource {
                     $envText = $item.ToString()
                     $envList += $envText.SubString(0, 1).ToLower() + $envText.SubString(1, $envText.Length - 1)
                 }
-                $url += "?environments=" + ($envList -join ",")
+                $rootNodeUrl += "?environments=" + ($envList -join ",")
             }
+
             $result = @()
-            $cohesityUrl = $cohesityServer + $url
-            $resp = Invoke-RestApi -Method Get -Uri $cohesityUrl
+            $resp = Invoke-RestApi -Method Get -Uri $rootNodeUrl
+
             if ($resp) {
                 $result = @($resp)
                 $groups = @($result | where-object { $null -eq $_.registrationInfo })
                 if($groups) {
                     foreach ($group in $groups) {
-                        $url = '/irisservices/api/v1/public/protectionSources?id=' + $group.protectionSource.id.ToString()
-                        $resp = Invoke-RestApi -Method Get -Uri $url
+                        $PSurl = '/irisservices/api/v1/public/protectionSources?id=' + $group.protectionSource.id.ToString()
+                        $resp = Invoke-RestApi -Method Get -Uri $PSurl
+
                         if($resp) {
                             $children = FlattenProtectionSourceNode -Nodes $resp -Type 2
                             foreach ($child in $children) {
@@ -68,6 +94,7 @@ function Get-CohesityProtectionSource {
                     }
                 }
             }
+
             # Skip kView, kAgent, kPuppeteer environment types and group nodes themselves
             $result = @($result | where-object {
                 $_.protectionSource.environment -ne "kAgent" `
@@ -75,6 +102,7 @@ function Get-CohesityProtectionSource {
                 -and $_.protectionSource.environment -ne "kPuppeteer" `
                 -and $null -ne $_.registrationInfo
             })
+
             # Make sure each source id is only listed once as it might repeat under different environments
             # we have to sort the rows based on protectionSource.id and remove any duplicate entries
             $result = @($result | Sort-Object -property @{expression={$_.protectionSource.id }} -Unique)


### PR DESCRIPTION
Description: Show example of how to add Source to current Protection Job.
Issue:
Show example of how to add Source to current Protection Job.
Error message:
Invoke-WebRequest : {"errorCode":"KInvalidRequest","message":"BackupSourceParams must be specified for all sources in a physical files job"}

There is no documentation on defining BackupSourceParams

Fix: BackupSourceParams field is missing, when user is including only
the physical source while protecting physical files