### PR TITLE
Added option to display unhealthy agent erros.

### DIFF
--- a/docs/cmdlets-reference/connect-cohesitycluster.md
+++ b/docs/cmdlets-reference/connect-cohesitycluster.md
@@ -7,17 +7,20 @@ Connects to a Cohesity Cluster and acquires an authentication token.
 
 ### UsingCreds (Default)
 ```
-Connect-CohesityCluster -Server <String> [-Port <Int64>] -Credential <PSCredential> [<CommonParameters>]
+Connect-CohesityCluster -Server <String> [-Port <Int64>] -Credential <PSCredential> [-UseMFA]
+ [-OtpType <OtpTypeEnum>] [<CommonParameters>]
 ```
 
 ### UsingAPIKey
 ```
-Connect-CohesityCluster -Server <String> [-Port <Int64>] [-APIKey <String>] [<CommonParameters>]
+Connect-CohesityCluster -Server <String> [-Port <Int64>] [-APIKey <String>] [-UseMFA] [-OtpType <OtpTypeEnum>]
+ [<CommonParameters>]
 ```
 
-### UsingMFA
+### UsingSessionId
 ```
-Connect-CohesityCluster -Server <String> [-Port <Int64>] [-UseMFA ] [-OtpType <String>] [<CommonParameters>]
+Connect-CohesityCluster -Server <String> [-Port <Int64>] [-SessionId <String>] [-UseMFA]
+ [-OtpType <OtpTypeEnum>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -39,7 +42,7 @@ Connects to a Cohesity Cluster at the address "192.168.1.100" using the provided
 Connect-CohesityCluster -Server 192.168.1.100 -Credential (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList "mydomain.com\admin", (ConvertTo-SecureString -AsPlainText "p@ssword" -Force))
 ```
 
-Connects to a Cohesity Cluster at the address "192.168.1.100" using the active directory user, by appending domain name(mydomain.com) to the user.
+Connects to a Cohesity Cluster at the address "192.168.1.100" using the active directory user, by appending fully qualified domain name(mydomain.com) to the user.
 
 ### EXAMPLE 3
 ```
@@ -50,17 +53,33 @@ Connects to a Cohesity Cluster at the address "192.168.1.100" for a user "user1"
 
 ### EXAMPLE 4
 ```
-Connect-CohesityCluster -Server 192.168.1.100 -APIKey "00000000-0000-0000-0000-000000000000"
+Connect-CohesityCluster -Server 192.168.1.100 -Credential (New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList "LOCAL\user1@tenant1", (ConvertTo-SecureString -AsPlainText "p@ssword" -Force))
+```
+
+Connects to a Cohesity Cluster at the address "192.168.1.100" for a user "user1" in the tenant "tenant1".
+
+### EXAMPLE 5
+```
+Connect-CohesityCluster -Server 192.168.1.100 -sessionId "sNsZuuvambLmrGO4XASUe+sIxeWpiv8udWXRAxVcOkk="
+```
+
+Connects to a Cohesity Cluster at the address "192.168.1.100" using the sessionId.
+
+### EXAMPLE 6
+```
+Connect-CohesityCluster -Server 192.168.1.100 -APIKey "00000000-0000-0000-0000-0000000000000"
 ```
 
 Connects to a Cohesity Cluster at the address "192.168.1.100" using the API Key (supported 6.5.1d onwards).
 
-### EXAMPLE 5
+### EXAMPLE 7
 ```
 Connect-CohesityCluster -Server 192.168.1.100 -UseMFA -OtpType Email
 ```
 
-Connects to a Cohesity Cluster at the address "192.168.1.100" using Multi-Factor Authentication(MFA). By default, OtpType will be considered as Totp if not provided. On trying to connect to the cluster using MFA, user will be prompted to provide OTP code.
+Connects to a Cohesity Cluster at the address "192.168.1.100" using Multi-Factor Authentication(MFA).
+By default, OtpType will be considered as Totp if not provided.
+On trying to connect to the cluster using MFA, user will be prompted to provide OTP code.
 
 ## PARAMETERS
 
@@ -125,6 +144,21 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -SessionId
+Cohesity Session Id key
+
+```yaml
+Type: String
+Parameter Sets: UsingSessionId
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -UseMFA
 Do MFA required ?
 
@@ -141,7 +175,11 @@ Accept wildcard characters: False
 ```
 
 ### -OtpType
-Specifies OTP type for MFA verification. 'Totp' implies the code is TOTP. 'Email' implies the code is email OTP.
+Specifies OTP type for MFA verification.
+'Totp' implies the code is TOTP.
+'Email' implies the code is email OTP.
+
+Possible values: Totp, Email
 
 ```yaml
 Type: OtpTypeEnum
@@ -151,7 +189,7 @@ Accepted values: Totp, Email
 
 Required: False
 Position: Named
-Default value: Totp
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/cmdlets-reference/find-cohesityfilesforrestore.md
+++ b/docs/cmdlets-reference/find-cohesityfilesforrestore.md
@@ -8,7 +8,8 @@ Finds a list of files and folders for restore based on the specified parameters.
 ```
 Find-CohesityFilesForRestore [-Environments <EnvironmentEnum[]>] [-FolderOnly <Boolean>] [-Search <String>]
  [-StartTime <Int64>] [-EndTime <Int64>] [-JobIds <Int64[]>] [-SourceIds <Int64[]>]
- [-RegisteredSourceIds <Int64[]>] [-StorageDomainIds <Int64[]>] [<CommonParameters>]
+ [-RegisteredSourceIds <Int64[]>] [-Paginate <Boolean>] [-PageSize <Int64>] [-PaginationCookie <String>]
+ [-StorageDomainIds <Int64[]>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -22,6 +23,21 @@ Find-CohesityFilesForRestore -Search "*txt"
 ```
 
 Returns only the files and folders that match the search pattern "txt".
+
+### EXAMPLE 2
+```
+Find-CohesityFilesForRestore -Search "*txt" -Paginate $true -PageSize 120
+```
+
+Returns 120(pageSize) entries that match the search pattern "txt".
+Pagination Cookie in the response can be used to fetch next list of entries.
+
+### EXAMPLE 3
+```
+Find-CohesityFilesForRestore -Search "*txt" -Paginate $true -PaginationCookie rrrgcrsgre -PageSize 200
+```
+
+Returns next set of entries that match the search pattern "txt" based on provided Pagiantion cookie.
 
 ## PARAMETERS
 
@@ -147,6 +163,57 @@ Only items from the listed registered sources are returned.
 
 ```yaml
 Type: Int64[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Paginate
+Specifies bool to control pagination of search results.
+Only valid for librarian queries.
+If this is set to true and a pagination cookie is provided, search will be resumed.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PageSize
+Specifies pagesize for pagination.
+Only valid for librarian queries.
+Effective only when Paginate is set to true.
+
+```yaml
+Type: Int64
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PaginationCookie
+Specifies cookie for resuming search if pagination is being used.
+Only valid for librarian queries.
+Effective only when Paginate is set to true.
+
+```yaml
+Type: String
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/cmdlets-reference/get-cohesityagentstatus.md
+++ b/docs/cmdlets-reference/get-cohesityagentstatus.md
@@ -1,16 +1,16 @@
 # Get-CohesityAgentStatus
 
 ## SYNOPSIS
-Gets a list of the agent status of physical servers.
+Get all agent status in a table view.
 
 ## SYNTAX
 
 ```
-Get-CohesityAgentStatus [<CommonParameters>]
+Get-CohesityAgentStatus
 ```
 
 ## DESCRIPTION
-Gets a list of the agent status of physical servers.
+Get all agent status in a table view.
 
 ## EXAMPLES
 
@@ -19,19 +19,14 @@ Gets a list of the agent status of physical servers.
 Get-CohesityAgentStatus
 ```
 
-Returns the agent status of physcial servers.
-The attributes authenticationErrorMessage and refreshErrorMessage would provide the error messages.
+Get all agent status.
 
 ## PARAMETERS
-
-### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
 ## OUTPUTS
 
-### System.Array
 ## NOTES
 Published by Cohesity
 

--- a/docs/cmdlets-reference/get-cohesityprotectionjob.md
+++ b/docs/cmdlets-reference/get-cohesityprotectionjob.md
@@ -96,7 +96,7 @@ NOTE: kPuppeteer refers to Cohesity's remote adapter.
 Type: EnvironmentEnum[]
 Parameter Sets: (All)
 Aliases:
-Accepted values: KVMware, KHyperV, KSQL, KView, KPuppeteer, KPhysical, KPure, KNimble, KAzure, KNetapp, KAgent, KGenericNas, KAcropolis, KPhysicalFiles, KIsilon, KGPFS, KKVM, KAWS, KExchange, KHyperVVSS, KOracle, KGCP, KFlashBlade, KAWSNative, KVCD, KO365, KO365Outlook, KHyperFlex, KGCPNative, KAzureNative, KKubernetes, KElastifile, KAD, KRDSSnapshotManager, KAWSSnapshotManager
+Accepted values: KVMware, KHyperV, KSQL, KView, KPuppeteer, KPhysical, KPure, KNimble, KAzure, KNetapp, KAgent, KGenericNas, KAcropolis, KPhysicalFiles, KIsilon, KGPFS, KKVM, KAWS, KExchange, KHyperVVSS, KOracle, KGCP, KFlashBlade, KAWSNative, KO365, KO365Outlook, KHyperFlex, KGCPNative, KAzureNative, KKubernetes, KElastifile, KAD, KRDSSnapshotManager, KCassandra, KMongoDB, KCouchbase, KHdfs, KHive, KHBase, KUDA, KO365Teams, KO365Group, KO365Exchange, KO365OneDrive, KO365Sharepoint, KO365PublicFolders
 
 Required: False
 Position: 4

--- a/docs/cmdlets-reference/get-cohesityprotectionpolicy.md
+++ b/docs/cmdlets-reference/get-cohesityprotectionpolicy.md
@@ -39,7 +39,7 @@ NOTE: "kPuppeteer" refers to Cohesity's Remote Adapter.
 Type: EnvironmentEnum[]
 Parameter Sets: (All)
 Aliases:
-Accepted values: KVMware, KHyperV, KSQL, KView, KPuppeteer, KPhysical, KPure, KNimble, KAzure, KNetapp, KAgent, KGenericNas, KAcropolis, KPhysicalFiles, KIsilon, KGPFS, KKVM, KAWS, KExchange, KHyperVVSS, KOracle, KGCP, KFlashBlade, KAWSNative, KVCD, KO365, KO365Outlook, KHyperFlex, KGCPNative, KAzureNative, KKubernetes, KElastifile, KAD, KRDSSnapshotManager, KAWSSnapshotManager
+Accepted values: KVMware, KHyperV, KSQL, KView, KPuppeteer, KPhysical, KPure, KNimble, KAzure, KNetapp, KAgent, KGenericNas, KAcropolis, KPhysicalFiles, KIsilon, KGPFS, KKVM, KAWS, KExchange, KHyperVVSS, KOracle, KGCP, KFlashBlade, KAWSNative, KO365, KO365Outlook, KHyperFlex, KGCPNative, KAzureNative, KKubernetes, KElastifile, KAD, KRDSSnapshotManager, KCassandra, KMongoDB, KCouchbase, KHdfs, KHive, KHBase, KUDA, KO365Teams, KO365Group, KO365Exchange, KO365OneDrive, KO365Sharepoint, KO365PublicFolders
 
 Required: False
 Position: 1

--- a/docs/cmdlets-reference/get-cohesityprotectionsource.md
+++ b/docs/cmdlets-reference/get-cohesityprotectionsource.md
@@ -6,7 +6,8 @@ Gets a list of the registered protection sources filtered by the specified param
 ## SYNTAX
 
 ```
-Get-CohesityProtectionSource [[-Environments] <EnvironmentEnum[]>] [[-Id] <Int64>] [[-Name] <String>] [<CommonParameters>]
+Get-CohesityProtectionSource [[-Environments] <EnvironmentEnum[]>] [[-Id] <Int64>] [[-Name] <String>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -45,7 +46,7 @@ For example, set this parameter to 'kVMware' to only return the VMware sources.
 Type: EnvironmentEnum[]
 Parameter Sets: (All)
 Aliases:
-Accepted values: KVMware, KHyperV, KSQL, KView, KPuppeteer, KPhysical, KPure, KNimble, KAzure, KNetapp, KAgent, KGenericNas, KAcropolis, KPhysicalFiles, KIsilon, KGPFS, KKVM, KAWS, KExchange, KHyperVVSS, KOracle, KGCP, KFlashBlade, KAWSNative, KO365, KO365Outlook, KHyperFlex, KGCPNative, KAzureNative, KKubernetes, KElastifile, KAD, KRDSSnapshotManager, KVCD
+Accepted values: KVMware, KHyperV, KSQL, KView, KPuppeteer, KPhysical, KPure, KNimble, KAzure, KNetapp, KAgent, KGenericNas, KAcropolis, KPhysicalFiles, KIsilon, KGPFS, KKVM, KAWS, KExchange, KHyperVVSS, KOracle, KGCP, KFlashBlade, KAWSNative, KO365, KO365Outlook, KHyperFlex, KGCPNative, KAzureNative, KKubernetes, KElastifile, KAD, KRDSSnapshotManager, KCassandra, KMongoDB, KCouchbase, KHdfs, KHive, KHBase, KUDA, KO365Teams, KO365Group, KO365Exchange, KO365OneDrive, KO365Sharepoint, KO365PublicFolders
 
 Required: False
 Position: 1
@@ -70,7 +71,7 @@ Accept wildcard characters: False
 ```
 
 ### -Name
-Return only the protection source that matches the specified name.
+Return only the protection source that matches the sepecified object name.
 
 ```yaml
 Type: String

--- a/docs/cmdlets-reference/get-cohesityprotectionsourceobject.md
+++ b/docs/cmdlets-reference/get-cohesityprotectionsourceobject.md
@@ -102,7 +102,7 @@ For example, set this parameter to 'kVMware' to only return the Sources (and the
 Type: EnvironmentEnum[]
 Parameter Sets: (All)
 Aliases:
-Accepted values: KVMware, KHyperV, KSQL, KView, KPuppeteer, KPhysical, KPure, KNimble, KAzure, KNetapp, KAgent, KGenericNas, KAcropolis, KPhysicalFiles, KIsilon, KGPFS, KKVM, KAWS, KExchange, KHyperVVSS, KOracle, KGCP, KFlashBlade, KAWSNative, KO365, KO365Outlook, KHyperFlex, KGCPNative, KAzureNative, KKubernetes, KElastifile, KAD, KRDSSnapshotManager, KVCD
+Accepted values: KVMware, KHyperV, KSQL, KView, KPuppeteer, KPhysical, KPure, KNimble, KAzure, KNetapp, KAgent, KGenericNas, KAcropolis, KPhysicalFiles, KIsilon, KGPFS, KKVM, KAWS, KExchange, KHyperVVSS, KOracle, KGCP, KFlashBlade, KAWSNative, KO365, KO365Outlook, KHyperFlex, KGCPNative, KAzureNative, KKubernetes, KElastifile, KAD, KRDSSnapshotManager, KCassandra, KMongoDB, KCouchbase, KHdfs, KHive, KHBase, KUDA, KO365Teams, KO365Group, KO365Exchange, KO365OneDrive, KO365Sharepoint, KO365PublicFolders
 
 Required: False
 Position: 1

--- a/docs/cmdlets-reference/get-cohesityviewdirectoryquota.md
+++ b/docs/cmdlets-reference/get-cohesityviewdirectoryquota.md
@@ -6,7 +6,7 @@ Request to fetch directory quota for a view filtered by specified parameters.
 ## SYNTAX
 
 ```
-Get-CohesityViewDirectoryQuota [[-ViewName] <String>] [<CommonParameters>]
+Get-CohesityViewDirectoryQuota [[-ViewName] <String>] [[-PageCount] <Int32>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -23,6 +23,8 @@ Get-CohesityViewDirectoryQuota -ViewName view1
 ```
 Get-CohesityViewDirectoryQuota -ViewName view1 -PageCount 10
 ```
+
+Returns only specified count of view directory quota for each rest api call
 
 ## PARAMETERS
 
@@ -42,10 +44,10 @@ Accept wildcard characters: False
 ```
 
 ### -PageCount
-Specifies the number of view directory quota need to be returned while calling rest api
+Specifies number of views to be returned in each api call
 
 ```yaml
-Type: Integer
+Type: Int32
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/cmdlets-reference/new-cohesityprotectionjob.md
+++ b/docs/cmdlets-reference/new-cohesityprotectionjob.md
@@ -39,13 +39,6 @@ New-CohesityProtectionJob -Name 'Test-Job-View' -Description 'Protects a View' -
 
 Creates a protection job for protecting a Cohesity View.
 
-### EXAMPLE 2
-```
-New-CohesityProtectionJob -Name 'Test-Job-VMware' -Description 'Protects a VM' -PolicyName Bronze -Environment kVMware -SourceIds 123 -ParentSourceId 1 -StorageDomainName DefaultStorageDomain -AlertOn KFailure,KSuccess -EmailAddress abc@gmail.com -PauseFutureRuns
-```
-
-Creates a protection job for protecting a VM with specified settings.
-
 ## PARAMETERS
 
 ### -Name
@@ -211,7 +204,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: 12/12/2022 7:17:04 PM
+Default value: 4/14/2023 5:12:13 PM
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -297,13 +290,13 @@ Accept wildcard characters: False
 Specifies the environment that this job is protecting.
 Default is kView.
 
-Possible values: KVMware, KHyperV, KSQL, KView, KPuppeteer, KPhysical, KPure, KNimble, KAzure, KNetapp, KAgent, KGenericNas, KAcropolis, KPhysicalFiles, KIsilon, KGPFS, KKVM, KAWS, KExchange, KHyperVVSS, KOracle, KGCP, KFlashBlade, KAWSNative, KO365, KO365Outlook, KHyperFlex, KGCPNative, KAzureNative, KKubernetes, KElastifile, KAD, KRDSSnapshotManager, KCassandra, KMongoDB, KCouchbase, KHdfs, KHive, KHBase, KUDA, KO365Teams, KO365Group, KO365Exchange, KO365OneDrive, KO365Sharepoint, KO365PublicFolders, KAWSSnapshotManager, KVCD
+Possible values: KVMware, KHyperV, KSQL, KView, KPuppeteer, KPhysical, KPure, KNimble, KAzure, KNetapp, KAgent, KGenericNas, KAcropolis, KPhysicalFiles, KIsilon, KGPFS, KKVM, KAWS, KExchange, KHyperVVSS, KOracle, KGCP, KFlashBlade, KAWSNative, KO365, KO365Outlook, KHyperFlex, KGCPNative, KAzureNative, KKubernetes, KElastifile, KAD, KRDSSnapshotManager, KCassandra, KMongoDB, KCouchbase, KHdfs, KHive, KHBase, KUDA, KO365Teams, KO365Group, KO365Exchange, KO365OneDrive, KO365Sharepoint, KO365PublicFolders
 
 ```yaml
 Type: EnvironmentEnum
 Parameter Sets: (All)
 Aliases:
-Accepted values: KVMware, KHyperV, KSQL, KView, KPuppeteer, KPhysical, KPure, KNimble, KAzure, KNetapp, KAgent, KGenericNas, KAcropolis, KPhysicalFiles, KIsilon, KGPFS, KKVM, KAWS, KExchange, KHyperVVSS, KOracle, KGCP, KFlashBlade, KAWSNative, KO365, KO365Outlook, KHyperFlex, KGCPNative, KAzureNative, KKubernetes, KElastifile, KAD, KRDSSnapshotManager, KCassandra, KMongoDB, KCouchbase, KHdfs, KHive, KHBase, KUDA, KO365Teams, KO365Group, KO365Exchange, KO365OneDrive, KO365Sharepoint, KO365PublicFolders, KAWSSnapshotManager, KVCD
+Accepted values: KVMware, KHyperV, KSQL, KView, KPuppeteer, KPhysical, KPure, KNimble, KAzure, KNetapp, KAgent, KGenericNas, KAcropolis, KPhysicalFiles, KIsilon, KGPFS, KKVM, KAWS, KExchange, KHyperVVSS, KOracle, KGCP, KFlashBlade, KAWSNative, KO365, KO365Outlook, KHyperFlex, KGCPNative, KAzureNative, KKubernetes, KElastifile, KAD, KRDSSnapshotManager, KCassandra, KMongoDB, KCouchbase, KHdfs, KHive, KHBase, KUDA, KO365Teams, KO365Group, KO365Exchange, KO365OneDrive, KO365Sharepoint, KO365PublicFolders
 
 Required: False
 Position: Named

--- a/docs/cmdlets-reference/new-cohesityuser.md
+++ b/docs/cmdlets-reference/new-cohesityuser.md
@@ -143,7 +143,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: 12/2/2020 4:13:48 PM
+Default value: 4/14/2023 5:12:14 PM
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/cmdlets-reference/register-cohesityprotectionsourceacropolis.md
+++ b/docs/cmdlets-reference/register-cohesityprotectionsourceacropolis.md
@@ -58,13 +58,13 @@ Accept wildcard characters: False
 Specifies entity type for acropolis.
 Recommend to use the default value 'KStandaloneCluster'.
 
-Possible values: KPrismCentral, KStandaloneCluster, KCluster, KHost, KVirtualMachine, KNetwork, KStorageContainer
+Possible values: KStandaloneCluster
 
 ```yaml
 Type: AcropolisTypeEnum
 Parameter Sets: (All)
 Aliases:
-Accepted values: KPrismCentral, KStandaloneCluster, KCluster, KHost, KVirtualMachine, KNetwork, KStorageContainer
+Accepted values: KStandaloneCluster
 
 Required: False
 Position: Named

--- a/docs/cmdlets-reference/register-cohesityprotectionsourcenetapp.md
+++ b/docs/cmdlets-reference/register-cohesityprotectionsourcenetapp.md
@@ -58,13 +58,13 @@ Accept wildcard characters: False
 Type of NetApp server.
 Must be set to KCluster or KVserver.
 
-Possible values: KCluster, KVserver, KVolume
+Possible values: KCluster, KVserver
 
 ```yaml
 Type: NetappTypeEnum
 Parameter Sets: (All)
 Aliases:
-Accepted values: KCluster, KVserver, KVolume
+Accepted values: KCluster, KVserver
 
 Required: True
 Position: Named

--- a/docs/cmdlets-reference/register-cohesityprotectionsourcephysical.md
+++ b/docs/cmdlets-reference/register-cohesityprotectionsourcephysical.md
@@ -43,13 +43,13 @@ Accept wildcard characters: False
 Type of host.
 Must be set to KLinux or KWindows.
 
-Possible values: KLinux, KWindows, KAix, KSolaris, KSapHana, KOther
+Possible values: KLinux, KWindows, KAix, KSolaris, KSapHana, KSapOracle, KCockroachDB, KMySQL, KOther
 
 ```yaml
 Type: HostTypeEnum
 Parameter Sets: (All)
 Aliases:
-Accepted values: KLinux, KWindows, KAix, KSolaris, KSapHana, KOther
+Accepted values: KLinux, KWindows, KAix, KSolaris, KSapHana, KSapOracle, KCockroachDB, KMySQL, KOther
 
 Required: True
 Position: Named
@@ -62,13 +62,13 @@ Accept wildcard characters: False
 Type of physical host.
 Must be set to KHost or KWindowsCluster.
 
-Possible values: KGroup, KHost, KWindowsCluster, KOracleRACCluster, KOracleAPCluster
+Possible values: KHost
 
 ```yaml
 Type: PhysicalTypeEnum
 Parameter Sets: (All)
 Aliases:
-Accepted values: KGroup, KHost, KWindowsCluster, KOracleRACCluster, KOracleAPCluster
+Accepted values: KHost
 
 Required: True
 Position: Named

--- a/docs/cmdlets-reference/register-cohesityprotectionsourcevmware.md
+++ b/docs/cmdlets-reference/register-cohesityprotectionsourcevmware.md
@@ -43,13 +43,13 @@ Accept wildcard characters: False
 Type of VMware server.
 Must be set to KStandaloneHost or KVcenter.
 
-Possible values: KVCenter, KFolder, KDatacenter, KComputeResource, KClusterComputeResource, KResourcePool, KDatastore, KHostSystem, KVirtualMachine, KVirtualApp, KStandaloneHost, KStoragePod, KNetwork, KDistributedVirtualPortgroup, KTagCategory, KTag, KOpaqueNetwork, KvCloudDirector, KOrganization, KVirtualDatacenter, KCatalog, KOrgMetadata, KStoragePolicy
+Possible values: KVCenter, KStandaloneHost, KvCloudDirector
 
 ```yaml
 Type: VmwareTypeEnum
 Parameter Sets: (All)
 Aliases:
-Accepted values: KVCenter, KFolder, KDatacenter, KComputeResource, KClusterComputeResource, KResourcePool, KDatastore, KHostSystem, KVirtualMachine, KVirtualApp, KStandaloneHost, KStoragePod, KNetwork, KDistributedVirtualPortgroup, KTagCategory, KTag, KOpaqueNetwork, KvCloudDirector, KOrganization, KVirtualDatacenter, KCatalog, KOrgMetadata, KStoragePolicy
+Accepted values: KVCenter, KStandaloneHost, KvCloudDirector
 
 Required: True
 Position: Named

--- a/docs/cmdlets-reference/remove-cohesityviewshare.md
+++ b/docs/cmdlets-reference/remove-cohesityviewshare.md
@@ -10,7 +10,7 @@ Remove-CohesityViewShare -ShareName <String> [-WhatIf] [-Confirm] [<CommonParame
 ```
 
 ## DESCRIPTION
-Returns success if the Share is deleted.
+{{ Fill in the Description }}
 
 ## EXAMPLES
 

--- a/docs/cmdlets-reference/restore-cohesityfile.md
+++ b/docs/cmdlets-reference/restore-cohesityfile.md
@@ -227,13 +227,13 @@ Accept wildcard characters: False
 Specifies the operating system type of the target host.
 This is not required when restoring to a Physical Server but must be specified when restoring to a VM.
 
-Possible values: KLinux, KWindows, KAix, KSolaris, KSapHana, KOther
+Possible values: KLinux, KWindows, KAix, KSolaris, KSapHana, KSapOracle, KCockroachDB, KMySQL, KOther
 
 ```yaml
 Type: TargetHostTypeEnum
 Parameter Sets: (All)
 Aliases:
-Accepted values: KLinux, KWindows, KAix, KSolaris, KSapHana, KOther
+Accepted values: KLinux, KWindows, KAix, KSolaris, KSapHana, KSapOracle, KCockroachDB, KMySQL, KOther
 
 Required: False
 Position: Named

--- a/docs/cmdlets-reference/restore-cohesityfilev2.md
+++ b/docs/cmdlets-reference/restore-cohesityfilev2.md
@@ -1,0 +1,418 @@
+# Restore-CohesityFileV2
+
+## SYNOPSIS
+Restores the specified files or folders from a previous backup based on Cohesity V2 Rest APIs
+
+## SYNTAX
+
+```
+Restore-CohesityFileV2 [-sourceVM] <String> [[-targetVM] <String>] [[-fileNames] <Array>]
+ [[-taskName] <String>] [[-fileList] <String>] [[-vmUser] <String>] [[-vmPwd] <String>]
+ [[-restorePath] <String>] [[-restoreMethod] <String>] [-wait] [-showVersions] [[-runId] <String>]
+ [[-olderThan] <String>] [[-daysAgo] <Int32>] [-noIndex] [-localOnly] [[-targetEnvironment] <String>]
+ [-recoverToOriginalTarget] [-overwriteExisting] [-preserveAttributes] [-continueOnError] [-encryptionEnabled]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Restores the specified files or folders from a previous backup based on Cohesity V2 Rest APIs
+This script offers the -noIndex ($isDirectory = $True) parameter If the VM is not indexed.
+In this case, Most of the time the file/folder requested to restore is from a job run that is still in the indexing process using V2 apis.
+Restore is throwing errors if the VM is not indexed while using Restore-CohesityFile cmdlet which is based on V1 apis
+If the VM files/folders are indexed properly then use the Restore-CohesityFile cmdlet directly
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Restore-CohesityFileV2 -sourceVM "SQL-UT-VM2" -targetVM "SQL-UT-VM2" -fileNames "C:\.rnd"  -restorePath "C:\" -wait
+```
+
+### EXAMPLE 2
+```
+Restore-CohesityFileV2 -sourceVM "SQL-UT-VM2" -targetVM "SQL-UT-VMD2" -fileNames "C:\Users\"  -restorePath "C:\temp\" -wait
+```
+
+### EXAMPLE 3
+```
+Restore-CohesityFileV2 -sourceVM "SQL-UT-VM2" -targetVM "SQL-UT-VM2" -fileNames "C:\.rnd"  -restorePath "C:\" -taskName "Test_task" -wait
+```
+
+## PARAMETERS
+
+### -sourceVM
+Name of the Source VM, the filles need to be picked up for restore
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -targetVM
+Name of the Target V, the files need to be restored
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -fileNames
+One or more file paths to be restored
+
+```yaml
+Type: Array
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -taskName
+Task name of the restore job
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -fileList
+text file of file paths
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -vmUser
+UserName for VMTools, applicable only when restoreMethod selected as VMTools
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 6
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -vmPwd
+Password for vm tools, applicable only when restoreMethod selected as VMTools
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 7
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -restorePath
+Alternate path to restore files in the target VM
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 8
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -restoreMethod
+Different categories of the restore Job through different tools
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 9
+Default value: ExistingAgent
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -wait
+Wait for completion and report status.
+Script may delay to identify the status of the job status
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -showVersions
+Show available run dates
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -runId
+Restore from specified run ID
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 10
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -olderThan
+Restore from latest backup before date
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 11
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -daysAgo
+Restore from backup 'n' days ago
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 12
+Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -noIndex
+Specify the the VM file and folders are already indexed
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -localOnly
+{{ Fill localOnly Description }}
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -targetEnvironment
+Restore recovery fileandfolder - target environment
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 13
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -recoverToOriginalTarget
+Restore recovery fileandfolder - recover to original target
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -overwriteExisting
+Restore recovery fileandfolder - overwrite existing
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -preserveAttributes
+Restore recovery fileandfolder - preserveAttributes
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -continueOnError
+Restore recovery fileandfolder - continue on error over operation
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -encryptionEnabled
+Restore recovery fileandfolder - encryption enable/disable
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+Published by Cohesity
+
+## RELATED LINKS
+
+[https://cohesity.github.io/cohesity-powershell-module/#/README](https://cohesity.github.io/cohesity-powershell-module/#/README)
+

--- a/docs/cmdlets-reference/restore-cohesityoracledatabase.md
+++ b/docs/cmdlets-reference/restore-cohesityoracledatabase.md
@@ -1,0 +1,226 @@
+# Restore-CohesityOracleDatabase
+
+## SYNOPSIS
+From cluster restores the specified Oracle database from a previous backup.
+
+## SYNTAX
+
+```
+Restore-CohesityOracleDatabase [[-TaskName] <String>] [-SourceName] <String> [-SourceDatabaseName] <String>
+ [-OracleHome] <String> [-OracleBase] <String> [-TargetSourceId] <Int64> [-JobId] <Int64> [[-JobRunId] <Int64>]
+ [[-CaptureTailLogs] <String>] [[-NewDatabaseName] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+From cluster restores the specified Oracle database from a previous backup.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Restore-CohesityOracleDatabase -SourceName 10.2.14.31 -TargetSourceId 1277 -JobId 31520 -TargetHostId 770 -NewDatabaseName CohesityDB_r1
+```
+
+Restore Oracle database from cluster with database id 1279 , database instance id 1277 and job id as 31520
+
+## PARAMETERS
+
+### -TaskName
+Specifies the name of the restore task.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: "Restore-Oracle-Object-" + (Get-Date -Format "dddd-MM-dd-yyyy-HH-mm-ss").ToString()
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SourceName
+Specifies the source name of the Oracle database to restore.
+This can be obtained using Get-CohesityProtectionSource -Environments kOracle.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SourceDatabaseName
+Specifies a name of the database to recover.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OracleHome
+Specifies the Oracle home directory path.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OracleBase
+Specifies the Oracle base directory path.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TargetSourceId
+Specifies the id of Oracle source id to restore the database.
+
+```yaml
+Type: Int64
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 6
+Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -JobId
+Specifies the job id that backed up this Oracle instance and will be used for this restore.
+
+```yaml
+Type: Int64
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 7
+Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -JobRunId
+Specifies the job run id that captured the snapshot for this Oracle instance.
+If not specified the latest run is used.
+This field must be set if restoring to a different target host.
+
+```yaml
+Type: Int64
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 8
+Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CaptureTailLogs
+Specifies if the tail logs are to be captured before the restore operation.
+This is only applicable if restoring the database to its hosting Protection Source and the database is not being renamed.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 9
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NewDatabaseName
+Specifies a new name for the restored database.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 10
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+Published by Cohesity
+
+## RELATED LINKS
+
+[https://cohesity.github.io/cohesity-powershell-module/#/README](https://cohesity.github.io/cohesity-powershell-module/#/README)
+

--- a/docs/cmdlets-reference/restore-cohesityremotemssqlobject.md
+++ b/docs/cmdlets-reference/restore-cohesityremotemssqlobject.md
@@ -10,8 +10,8 @@ From remote cluster restores the specified MS SQL object from a previous backup.
 Restore-CohesityRemoteMSSQLObject [-TaskName <String>] -SourceId <Int64> -HostSourceId <Int64> -JobId <Int64>
  [-CaptureTailLogs] [-KeepCDC] [-NewDatabaseName <String>] [-NewInstanceName <String>]
  [-RestoreTimeSecs <Int64>] [-TargetDataFilesDirectory <String>] [-TargetLogFilesDirectory <String>]
- [-TargetSecondaryDataFilesDirectoryList <Object[]>] [-TargetHostId <Int64>] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [-TargetSecondaryDataFilesDirectoryList <Object[]>] [-DbRestoreOverwritePolicy] [-TargetHostId <Int64>]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Jobrun
@@ -20,7 +20,7 @@ Restore-CohesityRemoteMSSQLObject [-TaskName <String>] -SourceId <Int64> -HostSo
  [-JobRunId <Int64>] [-StartTime <Int64>] [-CaptureTailLogs] [-KeepCDC] [-NewDatabaseName <String>]
  [-NewInstanceName <String>] [-RestoreTimeSecs <Int64>] [-TargetDataFilesDirectory <String>]
  [-TargetLogFilesDirectory <String>] [-TargetSecondaryDataFilesDirectoryList <Object[]>]
- [-TargetHostId <Int64>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-DbRestoreOverwritePolicy] [-TargetHostId <Int64>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -30,13 +30,14 @@ From remote cluster restores the specified MS SQL object from a previous backup.
 
 ### EXAMPLE 1
 ```
-Restore-CohesityRemoteMSSQLObject -SourceId 1279 -HostSourceId 1277 -JobId 31520 -TargetHostId 770 -CaptureTailLogs:$false -NewDatabaseName CohesityDB_r1 -NewInstanceName MSSQLSERVER -TargetDataFilesDirectory "C:\temp" -TargetLogFilesDirectory "C:\temp"
+Restore-CohesityRemoteMSSQLObject -SourceId 1279 -HostSourceId 1277 -JobId 31520 -TargetHostId 770 -CaptureTailLogs:$false -NewDatabaseName CohesityDB_r1 -NewInstanceName MSSQLSERVER -TargetDataFilesDirectory "C:\temp" -TargetLogFilesDirectory "C:\temp" -DbRestoreOverwritePolicy:$true
 ```
 
 Restore MSSQL database from remote cluster with database id 1279 , database instance id 1277 and job id as 31520
 $mssqlObjects = Find-CohesityObjectsForRestore -Environments KSQL
 Get the source id, $mssqlObjects\[0\].SnapshottedSource.Id
 Get the source instance id, $mssqlObjects\[0\].SnapshottedSource.SqlProtectionSource.OwnerId
+Use the DbRestoreOverwritePolicy:$true for overriding the existing database
 
 ### EXAMPLE 2
 ```
@@ -285,6 +286,22 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DbRestoreOverwritePolicy
+This field will overwrite the existing db contents if it sets to true
+By default the db overwrite policy is false
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/cmdlets-reference/set-cohesityprotectionsource.md
+++ b/docs/cmdlets-reference/set-cohesityprotectionsource.md
@@ -27,8 +27,19 @@ $protecionSource = Get-CohesityProtectionSource -Id 121
 ```
 
 $protecionSource.Name = "UpdatedName"
+$protecionSource.Name = "UpdatedName"
 $protecionSource | Set-CohesityProtectionSource
 Returns updated registered protection sources when the object is piped.
+
+### EXAMPLE 3
+```
+Update the credentials of a VMware Protection Source.
+```
+
+$protecionSource = Get-CohesityProtectionSource -Id 1
+$protecionSource |Add-Member -Name username  -Value "Administrator" -Type NoteProperty
+$protecionSource |Add-Member -Name password  -Value "cohesity" -Type NoteProperty
+$protecionSource | Set-CohesityProtectionSource
 
 ## PARAMETERS
 

--- a/src/Cohesity.Powershell/Cohesity.PowerShell.Core.psd1
+++ b/src/Cohesity.Powershell/Cohesity.PowerShell.Core.psd1
@@ -8,7 +8,7 @@
 RootModule = 'Cohesity.PowerShell.Core.dll'
 
 # Version number of this module.
-ModuleVersion = '1.8.4'
+ModuleVersion = '1.8.5'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/Cohesity.Powershell/Cohesity.PowerShell.psd1
+++ b/src/Cohesity.Powershell/Cohesity.PowerShell.psd1
@@ -8,7 +8,7 @@
 RootModule = 'Cohesity.PowerShell.dll'
 
 # Version number of this module.
-ModuleVersion = '1.8.4'
+ModuleVersion = '1.8.5'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/Cohesity.Powershell/Scripts/View/Get-CohesityAgentStatus.ps1
+++ b/src/Cohesity.Powershell/Scripts/View/Get-CohesityAgentStatus.ps1
@@ -35,7 +35,7 @@ function Get-CohesityAgentStatus {
 
         foreach ($agent in $agents){
             if ($agent.healthStatus -eq "kUnHealthy"){
-                $agent | Add-Member -name error -Value $errors[$agent.hostIp] -MemberType NoteProperty
+                $agent | Add-Member -name errorStatus -Value $errors[$agent.hostIp] -MemberType NoteProperty
             }
         }
 

--- a/src/Cohesity.Powershell/Scripts/View/Get-CohesityAgentStatus.ps1
+++ b/src/Cohesity.Powershell/Scripts/View/Get-CohesityAgentStatus.ps1
@@ -18,8 +18,26 @@ function Get-CohesityAgentStatus {
 
     Process {
 
-        $url = "/irisservices/api/v1/public/reports/agents"
+        $baseUrl = "/irisservices/api/v1/public/"
+
+        $url = $baseUrl + "reports/agents"
         $agents = Invoke-RestApi -Method Get -Uri $url
+
+        # Incase of any registration error, add those unhealthy source error
+        # messages to the output.
+        $url = $baseUrl + "protectionSources/registrationInfo?environments=kPhysical"
+        $errors = @{}
+            $protectionSources = Invoke-RestApi -Method Get -Uri $url
+            foreach ($source in $protectionSources.rootNodes){
+                $errors.add(
+                    $source.rootNode.name, $source.registrationInfo.refreshErrorMessage)
+            }
+
+        foreach ($agent in $agents){
+            if ($agent.healthStatus -eq "kUnHealthy"){
+                $agent | Add-Member -name error -Value $errors[$agent.hostIp] -MemberType NoteProperty
+            }
+        }
 
         if ($agents -eq $Nil -or $agents.Count -eq 0) {
             Write-Output "No agent details found in the cluster."


### PR DESCRIPTION
1) Incase of errors, get-cohesityagent status returns the state of the
   physical server and not the error details.
2) If the agent status is unhealthy, error message details are also
   added in the response