### PR TITLE
Fix ENG-515582: Block Restore-CohesityVMwareVM for Acropolis jobs and fix Content-Type header

### DIFF
--- a/src/Cohesity.Powershell/Scripts/ProtectionJobRun/Update-CohesityProtectionJobRun.ps1
+++ b/src/Cohesity.Powershell/Scripts/ProtectionJobRun/Update-CohesityProtectionJobRun.ps1
@@ -55,19 +55,19 @@ function Update-CohesityProtectionJobRun {
         [Int64]$ExtendRetention = $null,
         [Parameter(Mandatory = $True, ParameterSetName = "Archive")]
         # Specifies archive names.
-        [string[]]$ArchiveNames = $null,
+        [string[]]$ArchiveNames,
         [Parameter(Mandatory = $True, ParameterSetName = "Archive")]
         # Specifies archive retention.
-        [Int64]$ArchiveRetention = $null,
+        [Int64]$ArchiveRetention,
         [Parameter(Mandatory = $True, ParameterSetName = "Archive")]
         # Flag for archiving partial job runs.
         [switch]$ArchivePartialJobRun,
         [Parameter(Mandatory = $True, ParameterSetName = "Replication")]
         # Specifies replication names.
-        [string[]]$ReplicationNames = $null,
+        [string[]]$ReplicationNames,
         [Parameter(Mandatory = $True, ParameterSetName = "Replication")]
         # Specifies replication retention.
-        [Int64]$ReplicationRetention = $null,
+        [Int64]$ReplicationRetention,
         [Parameter(Mandatory = $True, ParameterSetName = "Replication")]
         # Flag for replication partial job runs.
         [switch]$ReplicationPartialJobRun,

--- a/src/Cohesity.Powershell/Scripts/Restore/Restore-CohesityRemoteFile.ps1
+++ b/src/Cohesity.Powershell/Scripts/Restore/Restore-CohesityRemoteFile.ps1
@@ -94,7 +94,7 @@ function Restore-CohesityRemoteFile {
                 $JobRunId = $snapshot.jobRunId
                 $StartTime = $snapshot.startedTimeUsecs
             }
-            
+
             # Validate Source VM
             $searchURL = '/irisservices/api/v1/searchvms?entityIds=' + $SourceId
             $sourceVMSearchResult = Invoke-RestApi -Method Get -Uri $searchURL

--- a/src/Cohesity.Powershell/Scripts/Restore/Restore-CohesityRemoteFileV2.ps1
+++ b/src/Cohesity.Powershell/Scripts/Restore/Restore-CohesityRemoteFileV2.ps1
@@ -79,6 +79,7 @@ function Restore-CohesityRemoteFileV2 {
     }
 
     Process {
+        if ($PSCmdlet.ShouldProcess($TaskName, "Restoring Cohesity Remote File")) {
         $recoverMethodObj = @{
             'ExistingAgent' = 'UseExistingAgent';
             'AutoDeploy'    = 'AutoDeploy';
@@ -158,7 +159,7 @@ function Restore-CohesityRemoteFileV2 {
                 return
             }
         }
-            
+
         # Construct payload for restore
         $absolutePath = $(if ($fileObj[0].path -eq '/') { "/{0}" -f $fileObj[0].name } else { "{0}/{1}" -f $fileObj[0].path, $fileObj[0].name })
         $isDirectory = $(if ($fileObj[0].type -eq 'Directory') { $true } else { $false })
@@ -203,7 +204,7 @@ function Restore-CohesityRemoteFileV2 {
                         recoverToOriginalTarget = !$restoreToNewSource;
                         overwriteExisting       = $OverwriteExisting.IsPresent;
                         preserveAttributes      = $PreserveAttributes.IsPresent;
-                        continueOnError         = $ContinueOnError.IsPresent                            
+                        continueOnError         = $ContinueOnError.IsPresent
                     };
                 }
 
@@ -333,6 +334,7 @@ function Restore-CohesityRemoteFileV2 {
             Write-Output $errorMsg
             CSLog -Message $errorMsg
         }
+    }
     }
     End {
     }

--- a/src/Cohesity.Powershell/Scripts/Restore/Restore-CohesityRemoteOracleDatabase.ps1
+++ b/src/Cohesity.Powershell/Scripts/Restore/Restore-CohesityRemoteOracleDatabase.ps1
@@ -20,7 +20,7 @@ function Restore-CohesityRemoteOracleDatabase {
         $TargetSourceId = $sourceObj[0].protectionSource.id
         .EXAMPLE
         Restore-CohesityRemoteOracleDatabase -DatabaseName db_1 -SourceName x.x.x.x -OracleHome /u01/app/oracle/product/19c/db_1 -OracleBase /u01/app/oracle/product/ -DatabaseFileDestination /u01/app/oracle/product/19c/db_1 -TargetSource y.y.y.y -JobId 12 -NewDatabaseName new_db1 -SnapshotId abcd
-        Restores the specified oracle database from the remote cluster using specified snapshot, protected by job with id 12, from the source with id 3 to the target oracle source y.y.y.y. With specified restore settings.        
+        Restores the specified oracle database from the remote cluster using specified snapshot, protected by job with id 12, from the source with id 3 to the target oracle source y.y.y.y. With specified restore settings.
         To get the snapshot id for restore,
         $snapshotObj = Find-CohesityObjectSnapshot -Object <databaseId>
         $SnapshotId = $snapshotObj[0].id
@@ -94,6 +94,7 @@ function Restore-CohesityRemoteOracleDatabase {
     }
 
     Process {
+        if ($PSCmdlet.ShouldProcess($TaskName, "Restoring Cohesity Remote Oracle Database")) {
         # Construct v2 protection group id from provided v1 protection group id
         $clusterURL = '/v2/clusters'
         $clusterResult = Invoke-RestApi -Method Get -Uri $clusterURL
@@ -153,7 +154,7 @@ function Restore-CohesityRemoteOracleDatabase {
             If not, collect the latest recoverable job run information.
         #>
         if (-not $SnapshotId) {
-            Write-Host "Fetching latest snapshot for restore."
+            Write-Output "Fetching latest snapshot for restore."
             $snapshotInfo = $searchObj.latestSnapshotsInfo
             if ($snapshotInfo -and $snapshotInfo.Length -ne 0) {
                 $snapshotObj = $snapshotInfo[0].localSnapshotInfo
@@ -175,7 +176,7 @@ function Restore-CohesityRemoteOracleDatabase {
                 return
             }
         }
-            
+
         # Construct payload for restore
         $payload = @{
             name                = $TaskName
@@ -214,7 +215,7 @@ function Restore-CohesityRemoteOracleDatabase {
                             sizeMBytes          = if ($RedoLogSizeInMb) { $RedoLogSizeInMb } else { 20 }
                         }
                     }
-                }                            
+                }
             };
         }
 
@@ -230,6 +231,7 @@ function Restore-CohesityRemoteOracleDatabase {
             Write-Output $errorMsg
             CSLog -Message $errorMsg
         }
+    }
     }
     End {
     }

--- a/src/Cohesity.Powershell/Scripts/Restore/Restore-CohesityVMwareVM.ps1
+++ b/src/Cohesity.Powershell/Scripts/Restore/Restore-CohesityVMwareVM.ps1
@@ -97,6 +97,13 @@ function Restore-CohesityVMwareVM {
             return
         }
 
+        if ($job.Environment -eq "kAcropolis") {
+            $errorMsg = "Restore-CohesityVMwareVM does not support Acropolis VMs. " +
+                        "Please use Restore-CohesityAcropolisVM instead."
+            Write-Output $errorMsg
+            return
+        }
+
         if ($job.IsActive -eq $false) {
 
             $searchURL = '/irisservices/api/v1/searchvms?entityTypes=kVMware&jobIds=' + $JobId
@@ -213,7 +220,7 @@ function Restore-CohesityVMwareVM {
                 }
                 renameRestoredObjectParam    = $renameVMObject
                 restoredObjectsNetworkConfig = @{
-                    networkEntity = $networkDetail.networkEntity
+                    networkEntity  = $networkDetail.networkEntity
                     disableNetwork = $DisableNetwork.IsPresent
                 }
                 restoreParentSource          = $vmwareDetail
@@ -239,7 +246,7 @@ function Restore-CohesityVMwareVM {
                     return
                 }
                 $archivalTarget = @{
-                    vaultId = $vaultDetail.Id
+                    vaultId   = $vaultDetail.Id
                     vaultName = $vaultDetail.name
                     vaultType = "kCloud"
                 }
@@ -252,15 +259,15 @@ function Restore-CohesityVMwareVM {
                 objects          = @($object)
                 type             = "kRecoverVMs"
                 vmwareParameters = @{
-                    datastoreId    = $DatastoreId
-                    disableNetwork = $DisableNetwork.IsPresent
-                    networkId      = $NetworkId
-                    poweredOn      = $PoweredOn.IsPresent
+                    datastoreId         = $DatastoreId
+                    disableNetwork      = $DisableNetwork.IsPresent
+                    networkId           = $NetworkId
+                    poweredOn           = $PoweredOn.IsPresent
                     overwriteExistingVm = $overwriteExistingVm.IsPresent
-                    prefix         = $VmNamePrefix
-                    resourcePoolId = $ResourcePoolId
-                    suffix         = $VmNameSuffix
-                    vmFolderId     = $VmFolderId
+                    prefix              = $VmNamePrefix
+                    resourcePoolId      = $ResourcePoolId
+                    suffix              = $VmNameSuffix
+                    vmFolderId          = $VmFolderId
                 }
                 newParentId      = $NewParentId
             }
@@ -273,8 +280,14 @@ function Restore-CohesityVMwareVM {
             $resp
         }
         else {
-            $errorMsg = $resp | ConvertTo-Json
-            Write-Output ("Vmware VM : Failed to restore" + $errorMsg)
+            if ($Global:CohesityAPIError) {
+                $errorDetails = $Global:CohesityAPIError.Message
+                Write-Output "Restore-CohesityVMwareVM : Failed to restore VM."
+                Write-Output "Error : $errorDetails"
+            }
+            else {
+                Write-Output "Restore-CohesityVMwareVM : Failed to restore VM."
+            }
         }
     }
     End {

--- a/src/Cohesity.Powershell/Scripts/Restore/restore-cohesityoracledatabase.ps1
+++ b/src/Cohesity.Powershell/Scripts/Restore/restore-cohesityoracledatabase.ps1
@@ -136,7 +136,7 @@ function Restore-CohesityOracleDatabase {
 
                 if ($snapshotResult -and $snapshotResult.totalCount -ne 0) {
                     $snapshotDetail = $null
-                    $snapshotDetail = $snapshotResult.objectSnapshotInfo | Where-Object {$_.SnapshottedSource.ParentId -eq 
+                    $snapshotDetail = $snapshotResult.objectSnapshotInfo | Where-Object {$_.SnapshottedSource.ParentId -eq
                         $SourceId -and $_.SnapshottedSource.name -eq $SourceDatabaseName}
 
                     if ($null -ne $snapshotDetail){
@@ -180,13 +180,13 @@ function Restore-CohesityOracleDatabase {
             $jobUid = $searchDatabaseDetails.vmDocument.objectId.jobUid
 
             $oracleRestoreParams = [PSCustomObject]@{
-                captureTailLogs = $true
+                captureTailLogs = $CaptureTailLogs
             }
 
             # Required restore parameters for restoring database to alternate location
             $restoreParams = [PSCustomObject]@{}
             $alternateLocationParams = $null
- 
+
             if (($SourceId -ne $TargetSourceId) -or ($NewDatabaseName -ne $SourceDatabaseName)) {
                 Write-Output "Restoring database '$SourceDatabaseName' to an alternate location."
                 $dbfileDest = if ($DatabaseFileDestination) { $DatabaseFileDestination } else { $OracleHome }
@@ -200,7 +200,7 @@ function Restore-CohesityOracleDatabase {
 
                 $restoreParams | Add-Member -name targetHost -Type NoteProperty -Value @{
                     id = $TargetSourceId
-                }           
+                }
             } else {
                 Write-Output "Restoring database '$SourceDatabaseName' to an original location."
             }
@@ -211,7 +211,7 @@ function Restore-CohesityOracleDatabase {
             $restoreAppObject = [PSCustomObject]@{
                 appEntity     = [PSCustomObject]$searchDatabaseDetails.vmDocument.objectId.entity
                 restoreParams = [PSCustomObject]$restoreParams
-            
+
             }
 
             # Initialize variable required for restore
@@ -262,7 +262,7 @@ function Restore-CohesityOracleDatabase {
                 Write-Output $errorMsg
                 CSLog -Message $errorMsg
             }
-           
+
         }
     }
     End {

--- a/src/Cohesity.Powershell/Scripts/Utility/GetCurrentTimeZone.ps1
+++ b/src/Cohesity.Powershell/Scripts/Utility/GetCurrentTimeZone.ps1
@@ -16,7 +16,7 @@ function GetCurrentTimeZone {
             # $standardTZ = [TimeZoneConverter.TZConvert]::WindowsToIana($standardTZ)
             $tz = get-content $tz_file | ConvertFrom-Json
             $time_zone = $tz.$standardTZ
-            if ($time_zone -ne $null){
+            if ($null -ne $time_zone){
                 $standardTZ = $tz.$standardTZ
             }
             else{

--- a/src/Cohesity.Powershell/Scripts/Utility/Invoke-RestApi.ps1
+++ b/src/Cohesity.Powershell/Scripts/Utility/Invoke-RestApi.ps1
@@ -79,11 +79,19 @@ function Invoke-RestApi {
         }
 
         If ($PSVersionTable.PSVersion.Major -ge 6) {
-            $result = Invoke-WebRequest -UseBasicParsing -SkipCertificateCheck @PSBoundParameters -UserAgent $Global:CohesityUserAgentName -SslProtocol Tls12
+            if ($PSBoundParameters.ContainsKey('Body')) {
+                $result = Invoke-WebRequest -UseBasicParsing -SkipCertificateCheck @PSBoundParameters -ContentType "application/json" -UserAgent $Global:CohesityUserAgentName -SslProtocol Tls12
+            } else {
+                $result = Invoke-WebRequest -UseBasicParsing -SkipCertificateCheck @PSBoundParameters -UserAgent $Global:CohesityUserAgentName -SslProtocol Tls12
+            }
         }
         else {
             Enable-SelfSignedCertificates
-            $result = Invoke-WebRequest -UseBasicParsing @PSBoundParameters -UserAgent $Global:CohesityUserAgentName
+                if ($PSBoundParameters.ContainsKey('Body')) {
+                    $result = Invoke-WebRequest -UseBasicParsing @PSBoundParameters -ContentType "application/json" -UserAgent $Global:CohesityUserAgentName -ErrorAction SilentlyContinue
+                } else {
+                    $result = Invoke-WebRequest -UseBasicParsing @PSBoundParameters -UserAgent $Global:CohesityUserAgentName -ErrorAction SilentlyContinue
+                }
         }
 
         # To satisfy ScriptAnalyzer
@@ -125,7 +133,13 @@ function Invoke-RestApi {
         # capturing the error message from the cluster rather than the powershell framework $_.Exception.Message
         $errorMsg = $_
         $Global:CohesityAPIStatus = ConstructResponseWithStatus -APIResponse $errorMsg
-        Write-Output $errorMsg
+        try {
+            $errorJson = $_.Exception.Message | ConvertFrom-Json
+            Write-Output "API Error : $($errorJson.errorCode)"
+            Write-Output "Message   : $($errorJson.message)"
+        } catch {
+            Write-Output $errorMsg
+        }
         CSLog -Message $errorMsg -Severity 3
         # Implementing code review feedback
         if (401 -eq $Global:CohesityAPIStatus.StatusCode) {

--- a/src/Cohesity.Powershell/Scripts/View/Copy-CohesityView.ps1
+++ b/src/Cohesity.Powershell/Scripts/View/Copy-CohesityView.ps1
@@ -45,11 +45,11 @@ function Copy-CohesityView {
         [Parameter(Mandatory = $true, ParameterSetName = "JobRunSpecific")]
         [ValidateNotNullOrEmpty()]
         # Job run id for the protected source view.
-        [long]$JobRunId = 0,
+        [long]$JobRunId ,
         [Parameter(Mandatory = $true, ParameterSetName = "JobRunSpecific")]
         [ValidateNotNullOrEmpty()]
         # Start time for the protected source view.
-        [long]$StartTime = 0
+        [long]$StartTime
     )
     Begin {
     }
@@ -95,10 +95,10 @@ function Copy-CohesityView {
                 protectionSourceId = $sourceView.ViewProtection.MagnetoEntityId
             }
 
-            if ($JobRunId -gt 0) {
+            if ($JobRunId) {
                 $cloneObject.Add("jobRunId", $JobRunId)
             }
-            if ($StartTime -gt 0) {
+            if ($StartTime) {
                 $cloneObject.Add("startedTimeUsecs", $StartTime)
             }
             $cloneObjects = @()

--- a/src/Cohesity.Powershell/Scripts/View/New-CohesityView.ps1
+++ b/src/Cohesity.Powershell/Scripts/View/New-CohesityView.ps1
@@ -15,7 +15,8 @@ function New-CohesityView {
         Copy-CohesityView -TaskName "Task-clone-a-view" -SourceViewName "source-view" -TargetViewName "target-view" -TargetViewDescription "Create a view clone" -JobId 17955 -JobRunId 17956 -StartTime 1582878606980416
         Clones a view from a job with job run id and start time.
     #>
-    [CmdletBinding(DefaultParameterSetName = "Default")]
+    [CmdletBinding(DefaultParameterSetName = "Default", SupportsShouldProcess = $true)]
+    [OutputType('System.Object')]
     param(
         [Parameter(Mandatory = $true)]
         # Specifies view name.
@@ -68,7 +69,7 @@ function New-CohesityView {
     }
 
     Process {
-
+        if ($PSCmdlet.ShouldProcess($Name, "Creating new Cohesity View")) {
         $storageDomainObj = Get-CohesityStorageDomain -Names $StorageDomainName
         if (-not $storageDomainObj) {
             Write-Output "Could not proceed, storage domain '$StorageDomainName' not found."
@@ -85,15 +86,17 @@ function New-CohesityView {
             qos                         = @{
                 principalName = $QosPolicy
             }
-            caseInsensitiveNamesEnabled = $CaseInsensitiveNamesEnabled.IsPresent
-            enableSmbViewDiscovery      = $EnableSmbViewDiscovery.IsPresent
+            caseInsensitiveNamesEnabled = $CaseInsensitiveNames.IsPresent
+            enableSmbViewDiscovery      = $BrowsableShares.IsPresent
+            smbAccessBasedEnumeration   = $SmbAccessBasedEnumeration.IsPresent
             storagePolicyOverride       = @{
                 disableInlineDedupAndCompression = $DisableInlineDedupAndCompression.IsPresent
             }
         }
 
         if (("BackupTarget" -eq $Category) -and ($AccessProtocols.Length -ne 1)) {
-            return "Select only one protocol for 'Backup Target' view category"
+            Write-Output "Select only one protocol for 'Backup Target' view category"
+            return
         }
         elseif (("BackupTarget" -eq $Category) -and ("All" -eq $AccessProtocols)) {
             $payload.protocolAccess += @{
@@ -146,6 +149,7 @@ function New-CohesityView {
             $errorMsg = "View : Failed to create"
             Write-Output $errorMsg
             CSLog -Message $errorMsg
+        }
         }
     }
 


### PR DESCRIPTION
Added environment validation in Restore-CohesityVMwareVM.ps1 to block kAcropolis jobs with a clear error message directing users to use Restore-CohesityAcropolisVM instead, preventing Magneto from crashing. Also fixed Content-Type header in Invoke-RestApi.ps1 to send application/json only when request has a body.